### PR TITLE
Error: Bot ignore DM message if starting with command prefix

### DIFF
--- a/src/handlers/message_handler.rs
+++ b/src/handlers/message_handler.rs
@@ -61,10 +61,6 @@ async fn manage_incoming_message(
     msg: &Message,
     config: &Config,
 ) -> ModmailResult<()> {
-    if msg.content.starts_with(&config.command.prefix) {
-        return Ok(());
-    }
-
     if msg.author.bot {
         return Ok(());
     }


### PR DESCRIPTION
This pull request makes a small change to the message handling logic by removing a check for command prefix in the `manage_incoming_message` function. Now, messages that start with the command prefix will no longer be ignored solely for that reason.

* Removed the early return that ignored messages starting with the command prefix in `manage_incoming_message` in `src/handlers/message_handler.rs`. started with the command prefix