### PR TITLE
fix(reply): useless information displayed when staff sended reply to user

### DIFF
--- a/src/commands/reply.rs
+++ b/src/commands/reply.rs
@@ -7,7 +7,7 @@ use crate::utils::extract_reply_content::extract_reply_content;
 use crate::utils::fetch_thread::fetch_thread;
 use std::collections::HashMap;
 
-use serenity::all::{Attachment, Color, Context, CreateAttachment, GuildId, Message, UserId};
+use serenity::all::{Attachment, Context, CreateAttachment, GuildId, Message, UserId};
 use crate::utils::hex_string_to_int::hex_string_to_int;
 use crate::utils::message_builder::MessageBuilder;
 


### PR DESCRIPTION
This pull request updates the reply command logic to improve how staff replies are sent to users. The main changes involve switching from sending staff-styled messages to user-styled messages and ensuring the correct color is applied to these messages using a utility function. The changes also include some minor imports and refactoring for consistency.

Message sending logic improvements:

* Changed from using `MessageBuilder::staff_message` to `MessageBuilder::user_message` for replies sent to users, ensuring the message format is appropriate for user-facing messages. [[1]](diffhunk://#diff-012db29fd6eb1af2dccfda09abf74efa139c57307b03a894fd9073edfef908c8L126-R129) [[2]](diffhunk://#diff-012db29fd6eb1af2dccfda09abf74efa139c57307b03a894fd9073edfef908c8L190-R193) [[3]](diffhunk://#diff-012db29fd6eb1af2dccfda09abf74efa139c57307b03a894fd9073edfef908c8L222-R227)
* Added the `.color()` method to set the message color using `hex_string_to_int` and the color value from the configuration, so replies are visually consistent with staff branding. [[1]](diffhunk://#diff-012db29fd6eb1af2dccfda09abf74efa139c57307b03a894fd9073edfef908c8L126-R129) [[2]](diffhunk://#diff-012db29fd6eb1af2dccfda09abf74efa139c57307b03a894fd9073edfef908c8L190-R193) [[3]](diffhunk://#diff-012db29fd6eb1af2dccfda09abf74efa139c57307b03a894fd9073edfef908c8L222-R227)