### PR TITLE
fix(threads/db): avoid duplicate tickets and move to SQLx migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ node_modules
 db/db.sqlite
 .idea
 .sqlx
-migrations
 .vscode/
 package-lock.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "lazy_static",
  "reqwest 0.12.22",
  "serde",
  "serenity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,12 @@ edition = "2024"
 [dependencies]
 serde = { version = "*", features = ["derive"] }
 serenity = "0.12.4"
-sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "macros"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "macros", "migrate"] }
 tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
 toml = "0.9.5"
 reqwest = "0.12.22"
 async-trait = "0.1.88"
 chrono = { version = "0.4.41", features = ["serde"] }
-lazy_static = "1.5.0"
 
 [dependencies.uuid]
 version = "1.18.0"

--- a/migrations/20250815145017_create_tables.sql
+++ b/migrations/20250815145017_create_tables.sql
@@ -1,0 +1,51 @@
+-- CreateTable (idempotent)
+CREATE TABLE IF NOT EXISTS "blocked_users" (
+    "user_id" TEXT NOT NULL PRIMARY KEY,
+    "user_name" TEXT NOT NULL,
+    "blocked_by" TEXT NOT NULL,
+    "blocked_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable (idempotent)
+CREATE TABLE IF NOT EXISTS "threads" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "user_id" INTEGER NOT NULL,
+    "user_name" TEXT NOT NULL,
+    "channel_id" TEXT NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "next_message_number" INTEGER DEFAULT 1,
+    "status" INTEGER NOT NULL DEFAULT 1,
+    "user_left" BOOLEAN NOT NULL DEFAULT false
+);
+
+-- CreateTable (idempotent)
+CREATE TABLE IF NOT EXISTS "thread_messages" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "thread_id" TEXT NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "user_name" TEXT NOT NULL,
+    "is_anonymous" BOOLEAN NOT NULL,
+    "dm_message_id" TEXT,
+    "inbox_message_id" TEXT,
+    "message_number" INTEGER,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "content" TEXT NOT NULL,
+    "thread_status" INTEGER NOT NULL,
+    CONSTRAINT "thread_messages_thread_id_fkey" FOREIGN KEY ("thread_id") REFERENCES "threads" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable (idempotent)
+CREATE TABLE IF NOT EXISTS "staff_alerts" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "staff_user_id" INTEGER NOT NULL,
+    "thread_user_id" INTEGER NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "used" BOOLEAN NOT NULL DEFAULT false
+);
+
+-- CreateIndex (idempotent)
+CREATE UNIQUE INDEX IF NOT EXISTS "threads_id_key" ON "threads"("id");
+
+-- CreateIndex (idempotent)
+CREATE UNIQUE INDEX IF NOT EXISTS "thread_messages_id_key" ON "thread_messages"("id");

--- a/migrations/20250815161000_unique_open_and_metadata.sql
+++ b/migrations/20250815161000_unique_open_and_metadata.sql
@@ -1,0 +1,23 @@
+-- Create system metadata table if missing
+CREATE TABLE IF NOT EXISTS system_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Initialize last_recovery_timestamp if absent
+INSERT OR IGNORE INTO system_metadata (key, value)
+VALUES ('last_recovery_timestamp', datetime('now'));
+
+-- Close duplicate open threads per user (keep oldest)
+UPDATE threads
+SET status = 0
+WHERE status = 1
+  AND rowid NOT IN (
+    SELECT MIN(rowid) FROM threads WHERE status = 1 GROUP BY user_id
+);
+
+-- Ensure a single open thread per user via partial unique index
+CREATE UNIQUE INDEX IF NOT EXISTS idx_threads_unique_open_per_user
+ON threads(user_id)
+WHERE status = 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,30 +12,30 @@ model blocked_users {
 }
 
 model threads {
-  id              String            @id @unique
-  user_id         Int
-  user_name       String
-  channel_id      String
-  created_at      DateTime          @default(now())
-  next_message_number Int?          @default(1)
-  status          Int               @default(1)
-  user_left       Boolean           @default(false)
-  thread_messages thread_messages[]
+  id                  String            @id @unique
+  user_id             Int
+  user_name           String
+  channel_id          String
+  created_at          DateTime          @default(now())
+  next_message_number Int?              @default(1)
+  status              Int               @default(1)
+  user_left           Boolean           @default(false)
+  thread_messages     thread_messages[]
 }
 
 model thread_messages {
-  id            Int   @id @unique() @default(autoincrement())
-  thread_id     String
-  thread        threads  @relation(fields: [thread_id], references: [id])
-  user_id       Int
-  user_name     String
-  is_anonymous  Boolean
-  dm_message_id String?
+  id               Int      @id @unique() @default(autoincrement())
+  thread_id        String
+  thread           threads  @relation(fields: [thread_id], references: [id])
+  user_id          Int
+  user_name        String
+  is_anonymous     Boolean
+  dm_message_id    String?
   inbox_message_id String?
-  message_number Int?
-  created_at    DateTime @default(now())
-  content       String
-  thread_status Int
+  message_number   Int?
+  created_at       DateTime @default(now())
+  content          String
+  thread_status    Int      @default(1)
 }
 
 model staff_alerts {
@@ -44,4 +44,10 @@ model staff_alerts {
   thread_user_id Int
   created_at     DateTime @default(now())
   used           Boolean  @default(false)
+}
+
+model system_metadata {
+  key        String   @id
+  value      String
+  updated_at DateTime @default(now())
 }

--- a/src/commands/edit/edit_command.rs
+++ b/src/commands/edit/edit_command.rs
@@ -118,6 +118,7 @@ fn extract_command_content(msg: &Message, config: &Config) -> ModmailResult<Stri
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
     use super::*;
     use crate::config::{BotConfig, CommandConfig, Config, ThreadConfig};
 
@@ -153,6 +154,7 @@ mod tests {
             error_handling: crate::config::ErrorHandlingConfig::default(),
             db_pool: None,
             error_handler: None,
+            thread_locks: Arc::new(Mutex::new(Default::default())),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub db_pool: Option<SqlitePool>,
     #[serde(skip)]
     pub error_handler: Option<Arc<ErrorHandler>>,
+    #[serde(skip)]
+    pub thread_locks: Arc<std::sync::Mutex<std::collections::HashMap<u64, Arc<tokio::sync::Mutex<()>>>>>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -117,6 +119,8 @@ pub fn load_config(path: &str) -> Config {
     let fallback_lang = config.language.get_fallback_language();
     let error_handler = Arc::new(ErrorHandler::with_languages(default_lang, fallback_lang));
     config.error_handler = Some(error_handler);
+
+    config.thread_locks = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
 
     config
 }

--- a/src/handlers/message_handler.rs
+++ b/src/handlers/message_handler.rs
@@ -100,6 +100,15 @@ async fn manage_incoming_message(
         }
     }
 
+    let user_key = msg.author.id.get();
+    let user_mutex = {
+        let mut map = config.thread_locks.lock().unwrap();
+        map.entry(user_key)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    };
+    let _guard = user_mutex.lock().await;
+
     if thread_exists(msg.author.id, pool).await {
         if let Some(channel_id_str) = get_thread_channel_by_user_id(msg.author.id, pool).await {
             let channel_id_num = channel_id_str

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -383,17 +383,35 @@ impl<'a> MessageBuilder<'a> {
 
         match target {
             MessageTarget::Channel(channel_id) => {
-                channel_id.send_message(&self.ctx.http, message).await
+
+                let message = match channel_id.send_message(&self.ctx.http, message).await {
+                    Ok(message) => message,
+                    Err(err) => return Err(err)
+                };
+
+                Ok(message)
             }
             MessageTarget::User(user_id) => {
                 let dm_channel = user_id.create_dm_channel(&self.ctx.http).await?;
-                dm_channel.send_message(&self.ctx.http, message).await
+
+                let message = match dm_channel.send_message(&self.ctx.http, message).await {
+                    Ok(message) => message,
+                    Err(err) => return Err(err)
+                };
+
+                Ok(message)
             }
             MessageTarget::Reply(original_message) => {
-                original_message
+                let message = match original_message
                     .channel_id
                     .send_message(&self.ctx.http, message)
                     .await
+                {
+                    Ok(message) => message,
+                    Err(err) => return Err(err)
+                };
+
+                Ok(message)
             }
         }
     }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the modmail system, focusing on database migration management, thread handling, and concurrency safety. The most significant changes include switching to SQLx's migration system, enforcing a single open thread per user, adding a metadata table for system state, and introducing per-user locks to prevent race conditions when handling threads.

**Database migration and schema improvements:**

* Migrated database schema management to SQLx's migration system by adding the `"migrate"` feature to the `sqlx` dependency in `Cargo.toml` and removing manual migration code from `src/db/operations/init.rs`. Now, migrations are handled via SQL files in the `migrations/` directory for better maintainability and atomic schema updates. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L9-L15) [[2]](diffhunk://#diff-7468d280ead734b97028a3e836a7c5957147e6a76ff492b3b91a880eb71f616aL21-L117)
* Added new migration files to create and update tables for `blocked_users`, `threads`, `thread_messages`, `staff_alerts`, and `system_metadata`, and established unique indexes to enforce data integrity. [[1]](diffhunk://#diff-c5813ffe66ff5a96ffaaafa6f0a4e4b8866f6f8f965999d169560a25840b147eR1-R51) [[2]](diffhunk://#diff-3b16fd8e0760c6eb01d31b153afedbcb972810aeb380b29d314de157756dfbcbR1-R23)
* Enforced a single open thread per user by closing duplicate open threads and adding a partial unique index on `threads(user_id)` where `status = 1`, preventing race conditions and duplicate threads.

**Concurrency and thread safety:**

* Introduced a per-user locking mechanism using `Arc<Mutex<HashMap<u64, Arc<tokio::sync::Mutex<()>>>>` in the `Config` struct, ensuring that thread operations for each user are serialized and preventing race conditions when handling incoming messages. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR20-R21) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR123-R124) [[3]](diffhunk://#diff-77226234ecac37277d728d7dce9728b89a390a1099bd18b916bd04649935beeeR103-R111) [[4]](diffhunk://#diff-b0222b92c5c99c5b480e77bb5b7df3b31aaa90d9bac22de7e0910489426599f2R121) [[5]](diffhunk://#diff-b0222b92c5c99c5b480e77bb5b7df3b31aaa90d9bac22de7e0910489426599f2R157)

**Thread creation and message routing logic:**

* Refactored thread creation logic in `src/modules/threads.rs` to ensure only the canonical thread channel is used, deleting any duplicate channels and routing messages and system notifications to the correct channel. [[1]](diffhunk://#diff-cd323969d3c116331df17535f1c91a57a97a74aa0453865eb230ecb2b859767aR10) [[2]](diffhunk://#diff-cd323969d3c116331df17535f1c91a57a97a74aa0453865eb230ecb2b859767aR47-R80) [[3]](diffhunk://#diff-cd323969d3c116331df17535f1c91a57a97a74aa0453865eb230ecb2b859767aL55-R104)

**Other improvements:**

* Improved error handling in `MessageBuilder::send` to ensure all message send operations return a consistent result, simplifying error propagation.
* Updated Prisma schema to add the `system_metadata` model and set a default value for `thread_status` in `thread_messages`. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL38-R38) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR48-R53)