### PR TITLE
feat(message): add staff role on staff reply message

### DIFF
--- a/src/commands/edit/message_ops.rs
+++ b/src/commands/edit/message_ops.rs
@@ -78,7 +78,9 @@ pub async fn format_new_message<'a>(
         let mut inbox_builder = MessageBuilder::anonymous_staff_message(ctx, config, msg.author.id)
             .content(content.to_string())
             .with_message_number(message_number);
-        if let Some(role_name) = &top_role_name { inbox_builder = inbox_builder.with_role(role_name.clone()); }
+        if let Some(role_name) = &top_role_name {
+            inbox_builder = inbox_builder.with_role(role_name.clone());
+        }
 
         let mut dm_builder = MessageBuilder::anonymous_staff_message(ctx, config, msg.author.id)
             .content(content.to_string());
@@ -89,11 +91,15 @@ pub async fn format_new_message<'a>(
         let mut inbox_builder = MessageBuilder::staff_message(ctx, config, msg.author.id, msg.author.name.clone())
             .content(content.to_string())
             .with_message_number(message_number);
-        if let Some(role_name) = &top_role_name { inbox_builder = inbox_builder.with_role(role_name.clone()); }
+        if let Some(role_name) = &top_role_name {
+            inbox_builder = inbox_builder.with_role(role_name.clone());
+        }
 
         let mut dm_builder = MessageBuilder::staff_message(ctx, config, msg.author.id, msg.author.name.clone())
             .content(content.to_string());
-        if let Some(role_name) = &top_role_name { dm_builder = dm_builder.with_role(role_name.clone()); }
+        if let Some(role_name) = &top_role_name {
+            dm_builder = dm_builder.with_role(role_name.clone());
+        }
 
         Ok((inbox_builder, dm_builder))
     }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -603,7 +603,9 @@ impl<'a> StaffReply<'a> {
             MessageBuilder::staff_message(self.ctx, self.config, self.staff_user_id, self.staff_username.clone())
         };
         if !self.is_anonymous {
-            if let Some(role_name) = &top_role_name { thread_builder = thread_builder.with_role(role_name.clone()); }
+            if let Some(role_name) = &top_role_name {
+                thread_builder = thread_builder.with_role(role_name.clone());
+            }
         }
 
         thread_builder = thread_builder
@@ -622,7 +624,9 @@ impl<'a> StaffReply<'a> {
                 MessageBuilder::staff_message(self.ctx, self.config, self.staff_user_id, self.staff_username.clone())
             };
             if !self.is_anonymous {
-                if let Some(role_name) = &top_role_name { dm_builder = dm_builder.with_role(role_name.clone()); }
+                if let Some(role_name) = &top_role_name {
+                    dm_builder = dm_builder.with_role(role_name.clone());
+                }
             }
 
             dm_builder = dm_builder


### PR DESCRIPTION
This pull request enhances staff message formatting by including the sender's highest role (excluding `@everyone`) in both thread and DM messages. The changes ensure that staff replies and new messages display the sender's top role for greater clarity and context. Additionally, the formatting of the display name has been updated for consistency.

**Role display improvements:**

* Added logic in `format_new_message` (`src/commands/edit/message_ops.rs`) and `StaffReply::send_and_record` (`src/utils/message_builder.rs`) to retrieve and include the sender's highest guild role name (excluding `@everyone`) in messages. [[1]](diffhunk://#diff-8df3e9dc6191da7f1bd56d561a826fcaaaaad3cde0c3564f131055d97d7ff941R61-R98) [[2]](diffhunk://#diff-c4ef9ee49c4c85076c0dd1d2a32125f86eda07b7c3c6cb0eca079e2c7f2c306cR576-R608)
* Updated message construction to append the top role to both thread and DM messages for staff replies, unless the message is anonymous. [[1]](diffhunk://#diff-8df3e9dc6191da7f1bd56d561a826fcaaaaad3cde0c3564f131055d97d7ff941R61-R98) [[2]](diffhunk://#diff-c4ef9ee49c4c85076c0dd1d2a32125f86eda07b7c3c6cb0eca079e2c7f2c306cR576-R608) [[3]](diffhunk://#diff-c4ef9ee49c4c85076c0dd1d2a32125f86eda07b7c3c6cb0eca079e2c7f2c306cL591-R633)

**Display name formatting:**

* Changed the display name format from `username [role]` to `username  (role)` for consistency in both thread and DM messages. [[1]](diffhunk://#diff-c4ef9ee49c4c85076c0dd1d2a32125f86eda07b7c3c6cb0eca079e2c7f2c306cL255-R255) [[2]](diffhunk://#diff-c4ef9ee49c4c85076c0dd1d2a32125f86eda07b7c3c6cb0eca079e2c7f2c306cL336-R336)