### PR TITLE
feat(thread): a thread can be delete by delete the ticket channel

### DIFF
--- a/src/db/operations/threads.rs
+++ b/src/db/operations/threads.rs
@@ -148,6 +148,14 @@ pub async fn is_a_ticket_channel(channel_id: ChannelId, pool: &SqlitePool) -> bo
         .unwrap_or(false)
 }
 
+pub async fn is_an_opened_ticket_channel(channel_id: ChannelId, pool: &SqlitePool) -> bool {
+    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM threads WHERE channel_id = ? AND status = 1)")
+        .bind(channel_id.to_string())
+        .fetch_one(pool)
+        .await
+        .unwrap_or(false)
+}
+
 pub async fn get_all_opened_threads(pool: &SqlitePool) -> Vec<Thread> {
     let rows =
         sqlx::query!("SELECT id, user_id, user_name, channel_id FROM threads WHERE status = 1")

--- a/src/handlers/guild_handler.rs
+++ b/src/handlers/guild_handler.rs
@@ -4,8 +4,10 @@ use crate::features::make_buttons;
 use crate::i18n::get_translated_message;
 use crate::utils::message::message_builder::MessageBuilder;
 use async_trait::async_trait;
-use serenity::all::{ButtonStyle, Context, GuildChannel};
+use serenity::all::{ButtonStyle, Context, GuildChannel, Message};
 use serenity::client::EventHandler;
+use crate::db::close_thread;
+use crate::db::threads::is_an_opened_ticket_channel;
 
 pub struct GuildHandler {
     pub config: Config,
@@ -41,7 +43,7 @@ impl EventHandler for GuildHandler {
         }
 
         if let Some(topic) = &thread.topic
-            && *topic == MODMAIL_MANAGED_TOPIC.to_string()
+            && *topic == MODMAIL_MANAGED_TOPIC
         {
             return;
         }
@@ -76,5 +78,33 @@ impl EventHandler for GuildHandler {
             .to_channel(thread.id)
             .send()
             .await;
+    }
+
+    async fn channel_delete(&self, _ctx: Context, channel: GuildChannel, _messages: Option<Vec<Message>>) {
+        let pool = match &self.config.db_pool {
+            Some(pool) => pool,
+            None => {
+                eprintln!("Database pool is not set in config.");
+                return;
+            }
+        };
+
+        if is_an_opened_ticket_channel(channel.id, pool).await {
+            let thread = match get_thread_by_channel_id(&channel.id.to_string(), pool).await {
+                Some(thread) => thread,
+                None => {
+                    return;
+                }
+            };
+
+            match close_thread(&thread.id, pool).await {
+                Ok(_) => {
+                    println!("Close thread successfully by deleted channel!");
+                },
+                Err(e) => {
+                    eprintln!("Failed to close thread for deleted channel {}: {}", channel.id, e);
+                }
+            }
+        }
     }
 }

--- a/src/modules/threads.rs
+++ b/src/modules/threads.rs
@@ -102,7 +102,7 @@ async fn create_or_get_thread_for_user(
 
 pub async fn create_channel(ctx: &Context, msg: &Message, config: &Config) {
     let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
-    if let Err(_) = community_guild_id.member(&ctx.http, msg.author.id).await {
+    if (community_guild_id.member(&ctx.http, msg.author.id).await).is_err() {
         let error_msg = crate::i18n::get_translated_message(
             config,
             "server.not_in_community",


### PR DESCRIPTION
This pull request introduces a new mechanism for automatically closing ticket threads when their associated channels are deleted. It also includes minor code improvements and refactoring for clarity and consistency. The most important changes are grouped below:

**Ticket thread management improvements:**

* Added a new function `is_an_opened_ticket_channel` in `threads.rs` to check if a channel is an open ticket channel, enabling more precise thread management.
* Implemented logic in `GuildHandler::channel_delete` to automatically close ticket threads when their channels are deleted, ensuring thread status remains consistent with channel state.

**Code refactoring and improvements:**

* Updated imports in `guild_handler.rs` to include necessary modules for thread and channel management.
* Refactored topic comparison in `GuildHandler` to use a direct string instead of allocating a new one, improving performance and readability.
* Simplified error handling in `create_channel` by switching to the more idiomatic `.is_err()` pattern.