### PR TITLE
fix(recovered_message): recovered_messages are now fully stored in DB

### DIFF
--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -36,7 +36,6 @@ use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex};
 
 static SUPPRESSED_DELETES: LazyLock<Mutex<HashSet<u64>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
-static LOGGED_DELETES: LazyLock<Mutex<HashSet<u64>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 type CommandFunc = Arc<StaticCommandFunc>;
 type StaticCommandFunc = dyn Fn(Context, Message, Config) -> Pin<Box<dyn Future<Output = ModmailResult<()>> + Send>>
@@ -195,36 +194,12 @@ impl EventHandler for GuildMessagesHandler {
             Err(_) => return,
         };
 
-        let mut skip_log = false;
-        {
-            let mut logged = LOGGED_DELETES.lock().unwrap();
-            let inbox_u64 = message_entry.inbox_message_id.as_ref().and_then(|s| s.parse::<u64>().ok());
-            let dm_u64 = message_entry.dm_message_id.as_ref().and_then(|s| s.parse::<u64>().ok());
-            let current_id = deleted_message_id.get();
-            if logged.contains(&current_id) {
-                return;
-            }
-            if let (Some(inbox_id), Some(dm_id)) = (inbox_u64, dm_u64) {
-                logged.insert(inbox_id);
-                logged.insert(dm_id);
-                if current_id != inbox_id {
-                    skip_log = true;
-                }
-            } else {
-                logged.insert(current_id);
-            }
-        }
-
         let is_dm = channel_id
             .to_channel(&ctx.http)
             .await
             .ok()
             .and_then(|c| c.private())
             .is_some();
-
-        if skip_log {
-            return;
-        }
 
         let thread_opt = get_thread_by_user_id(UserId::new(message_entry.user_id as u64), pool).await;
         let thread = match thread_opt { Some(t) => t, None => return };
@@ -258,7 +233,7 @@ impl EventHandler for GuildMessagesHandler {
             }
         }
 
-        if self.config.logs.show_log_on_edit && !is_dm {
+        if self.config.logs.show_log_on_edit {
             let guild_id = self.config.bot.get_community_guild_id();
             let mut params = HashMap::new();
 

--- a/src/modules/message_recovery.rs
+++ b/src/modules/message_recovery.rs
@@ -171,30 +171,11 @@ async fn recover_messages_for_thread(
             continue;
         }
 
-        if let Err(e) = insert_recovered_message(
-            &thread.id,
-            thread.user_id,
-            &thread.user_name,
-            &message.id.to_string(),
-            &content,
-            pool,
-        )
-        .await
-        {
-            eprintln!("Failed to insert recovered message: {}", e);
-            continue;
-        }
-
-        let _ = MessageBuilder::user_message(
-            ctx,
-            config,
-            message.author.id,
-            message.author.name.clone(),
-        )
-        .content(content)
-        .to_channel(channel_id)
-        .send()
-        .await;
+        let _ = MessageBuilder::begin_user_incoming(&ctx, config, thread.id.clone(), &message)
+            .to_thread(channel_id)
+            .content(content.clone())
+            .send_and_record(&pool)
+            .await;
 
         recovered_count += 1;
     }


### PR DESCRIPTION
This pull request refactors how deleted messages are tracked and logged in `GuildMessagesHandler`, simplifies message recovery logic, and makes logging behavior more consistent. The most significant changes are the removal of duplicate delete logging logic and improvements to message recovery and logging.

**Event Handling and Logging:**
* Removed the `LOGGED_DELETES` static variable and associated logic that prevented duplicate logging of deleted messages, simplifying the event handler and reducing state management complexity. [[1]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098L39) [[2]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098L198-L228)
* Logging on message edit now occurs regardless of whether the message is a DM, making log behavior more consistent.

**Message Recovery Logic:**
* Refactored the message recovery process to use `MessageBuilder::begin_user_incoming(...).send_and_record(...)` instead of manually inserting recovered messages and sending them, streamlining recovery and reducing code duplication.