### PR TITLE
feat(command): add an id command to retrieve id of a ticket user

### DIFF
--- a/src/commands/id.rs
+++ b/src/commands/id.rs
@@ -1,0 +1,36 @@
+use serenity::all::{Context, Message};
+use crate::config::Config;
+use crate::db::get_thread_by_channel_id;
+use crate::db::threads::is_a_ticket_channel;
+use crate::errors::{ModmailError, ModmailResult};
+use crate::errors::common::{database_connection_failed, thread_not_found};
+use crate::errors::ThreadError::NotAThreadChannel;
+use crate::utils::message::message_builder::MessageBuilder;
+
+pub async fn id(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
+    let db_pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(database_connection_failed)?;
+
+    if is_a_ticket_channel(msg.channel_id, &db_pool).await {
+        let thread = match get_thread_by_channel_id(&msg.channel_id.to_string(), db_pool).await {
+            Some(thread) => thread,
+            None => return Err(thread_not_found()),
+        };
+
+        let mut params = std::collections::HashMap::new();
+        params.insert("user".to_string(), format!("<@{}>", thread.user_id));
+        params.insert("id".to_string(), format!("||{}||", thread.user_id.to_string()));
+
+        let _ = MessageBuilder::system_message(ctx, config)
+            .translated_content("id.show_id", Some(&params), None, None).await
+            .to_channel(msg.channel_id)
+            .send()
+            .await?;
+
+        Ok(())
+    } else {
+        Err(ModmailError::Thread(NotAThreadChannel))
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod recover;
 pub mod remove_staff;
 pub mod reply;
 pub mod test_errors;
+pub mod id;

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -34,6 +34,7 @@ use serenity::{
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex};
+use crate::commands::id::id;
 
 static SUPPRESSED_DELETES: LazyLock<Mutex<HashSet<u64>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
@@ -69,6 +70,7 @@ impl GuildMessagesHandler {
         wrap_command!(h.commands, ["force_close", "fc"], force_close);
         wrap_command!(h.commands, ["add_staff", "as"], add_staff);
         wrap_command!(h.commands, ["remove_staff", "rs"], remove_staff);
+        wrap_command!(h.commands, "id", id);
         h
     }
 }

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -569,4 +569,8 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         "add_staff.remove_success".to_string(),
         DictionaryMessage::new("The user {user} has been removed from the ticket successfully."),
     );
+    dict.messages.insert(
+        "id.show_id".to_string(),
+        DictionaryMessage::new("ID of {user} : {id}"),
+    );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -592,4 +592,8 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "add_staff.remove_success".to_string(),
         DictionaryMessage::new("L'utilisateur {user} a été retiré du ticket avec succès."),
     );
+    dict.messages.insert(
+        "id.show_id".to_string(),
+        DictionaryMessage::new("ID de {user} : {id}"),
+    );
 }


### PR DESCRIPTION
This pull request introduces a new `id` command to the bot, allowing users to retrieve and display the user ID associated with a ticket channel in both English and French. The implementation includes the command logic, integration into the command handler, and localization support.

**New Command Addition:**

* Added a new `id` command in `src/commands/id.rs` that checks if the channel is a ticket, retrieves the corresponding thread, and sends a message displaying the user ID.
* Registered the `id` command in the command handler by importing it and adding it to the command list in `src/commands/mod.rs` and `src/handlers/guild_messages_handler.rs`. [[1]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdR14) [[2]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098R37) [[3]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098R73)

**Localization Support:**

* Added English and French translations for the `id.show_id` message, ensuring the command response is localized. [[1]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R572-R575) [[2]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R595-R598)