### PR TITLE
feat(commands): add help command to display all bot's commands

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,0 +1,29 @@
+use serenity::all::{Context, Message};
+use crate::config::Config;
+use crate::errors::ModmailResult;
+use crate::utils::message::message_builder::MessageBuilder;
+
+pub async fn help(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
+    let help_message = "# Available commands:\n\n\
+        **!add_staff <staff_id>** - Add a staff to an hidden ticket\n\
+        **!remove_staff <staff_id>** - Remove a staff from a ticket\n\
+        **!alert** - Alert staff in the current thread when a new user answer arrives \n\
+        **!help** - Show this help message\n\
+        **!reply <message>** - Reply to a ticket\n\
+        **!annonreply <message>** - Reply anonymously to a ticket\n\
+        **!close [reason]** - Close the current thread with an optional reason\n\
+        **!delete [reason]** - Delete the current thread with an optional reason\n\
+        **!hide** - Make the current thread hidden to non-staff members\n\
+        **!new_thread <user_id>** - Create a new ticket with a specific user\n\
+        **!alert [cancel]** - Set or cancel an alert for staff in the current thread\n\
+        **!force_close** - Force close the current thread if it's orphaned\n\
+        **!id** - Show the user ID associated with the current thread";
+
+    MessageBuilder::system_message(ctx, config)
+        .content(help_message)
+        .to_channel(msg.channel_id)
+        .send()
+        .await?;
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod recover;
 pub mod remove_staff;
 pub mod reply;
 pub mod test_errors;
+pub mod help;

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -37,6 +37,7 @@ use serenity::{
 use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex};
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use crate::commands::help::help;
 
 static SUPPRESSED_DELETES: LazyLock<Mutex<HashSet<u64>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
@@ -74,6 +75,7 @@ impl GuildMessagesHandler {
         wrap_command!(h.commands, ["add_staff", "as"], add_staff);
         wrap_command!(h.commands, ["remove_staff", "rs"], remove_staff);
         wrap_command!(h.commands, "id", id);
+        wrap_command!(h.commands, "help", help);
         h
     }
 }


### PR DESCRIPTION
This pull request adds a new `!help` command to the bot, allowing users to easily view a list of available commands and their descriptions. The implementation includes registering the command, importing the necessary function, and providing a formatted help message.

**New command functionality:**

* Added a `help` command handler in `src/commands/help.rs` that sends a formatted list of available commands and their descriptions to the channel.
* Registered the `help` command in the command module (`src/commands/mod.rs`).
* Imported the `help` function into the guild messages handler (`src/handlers/guild_messages_handler.rs`).
* Registered the `help` command in the handler's command list, making it available for use.