### PR TITLE
refactor(slash commands): ensure that slash commands return a modmailresult

### DIFF
--- a/src/commands/test_errors.rs
+++ b/src/commands/test_errors.rs
@@ -239,7 +239,9 @@ pub async fn test_all_errors(ctx: &Context, msg: &Message, config: &Config) -> M
             )
             .await;
 
-        let _ = error_handler.reply_with_error(ctx, msg, &error).await;
+        let _ = error_handler
+            .reply_to_msg_with_error(ctx, msg, &error)
+            .await;
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }

--- a/src/errors/dictionary.rs
+++ b/src/errors/dictionary.rs
@@ -213,6 +213,11 @@ impl DictionaryManager {
                     params.insert("command".to_string(), cmd.clone());
                     ("command.unknown_command".to_string(), Some(params))
                 }
+                CommandError::UnknownSlashCommand(cmd) => {
+                    let mut params = HashMap::new();
+                    params.insert("command".to_string(), cmd.clone());
+                    ("command.unknown_slash_command".to_string(), Some(params))
+                }
                 CommandError::InsufficientPermissions => {
                     ("command.insufficient_permissions".to_string(), None)
                 }
@@ -224,6 +229,7 @@ impl DictionaryManager {
                 ThreadError::ThreadCreationFailed => ("thread.creation_failed".to_string(), None),
                 ThreadError::UserStillInServer => ("thread.user_still_in_server".to_string(), None),
                 ThreadError::NotAThreadChannel => ("thread.not_a_thread_channel".to_string(), None),
+                ThreadError::CategoryNotFound => ("thread.category_not_found".to_string(), None),
                 _ => ("thread.not_found".to_string(), None),
             },
             ModmailError::Message(msg_err) => match msg_err {

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -53,6 +53,8 @@ pub enum DiscordError {
     MessageTooLong,
     ChannelCreationFailed,
     DmCreationFailed,
+    FailedToFetchCategories,
+    FailedToMoveChannel,
 }
 
 #[derive(Debug, Clone)]
@@ -61,10 +63,12 @@ pub enum CommandError {
     MissingArguments,
     InvalidArguments(String),
     UnknownCommand(String),
+    UnknownSlashCommand(String),
     CommandFailed(String),
     InsufficientPermissions,
     CommandNotAvailable,
     CooldownActive(u64),
+    NotInThread(),
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +84,7 @@ pub enum ThreadError {
     UserNotInTheServer,
     UserStillInServer,
     NotAThreadChannel,
+    CategoryNotFound,
 }
 
 #[derive(Debug, Clone)]
@@ -178,6 +183,8 @@ impl fmt::Display for DiscordError {
             DiscordError::MessageTooLong => write!(f, "Message too long"),
             DiscordError::ChannelCreationFailed => write!(f, "Failed to create channel"),
             DiscordError::DmCreationFailed => write!(f, "Failed to create DM channel"),
+            DiscordError::FailedToFetchCategories => write!(f, "Failed to fetch categories"),
+            DiscordError::FailedToMoveChannel => write!(f, "Failed to move channel"),
         }
     }
 }
@@ -189,12 +196,14 @@ impl fmt::Display for CommandError {
             CommandError::MissingArguments => write!(f, "Missing arguments"),
             CommandError::InvalidArguments(arg) => write!(f, "Invalid arguments: {}", arg),
             CommandError::UnknownCommand(cmd) => write!(f, "Unknown command: {}", cmd),
+            CommandError::UnknownSlashCommand(cmd) => write!(f, "Unknown slash command: {}", cmd),
             CommandError::CommandFailed(msg) => write!(f, "Command failed: {}", msg),
             CommandError::InsufficientPermissions => write!(f, "Insufficient permissions"),
             CommandError::CommandNotAvailable => write!(f, "Command not available"),
             CommandError::CooldownActive(seconds) => {
                 write!(f, "Cooldown active: {} seconds", seconds)
             }
+            CommandError::NotInThread() => write!(f, "This command can only be used in a thread"),
         }
     }
 }
@@ -216,6 +225,7 @@ impl fmt::Display for ThreadError {
                 "User still in the server. Use the 'close' command to close this ticket."
             ),
             ThreadError::NotAThreadChannel => write!(f, "This channel is not a ticket channel"),
+            ThreadError::CategoryNotFound => write!(f, "Category not found"),
         }
     }
 }

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -117,7 +117,9 @@ async fn manage_incoming_message(
             .await;
 
             let error = common::validation_failed(&error_msg);
-            let _ = error_handler.reply_with_error(ctx, msg, &error).await;
+            let _ = error_handler
+                .reply_to_msg_with_error(ctx, msg, &error)
+                .await;
             return Err(error);
         }
     }
@@ -136,7 +138,9 @@ async fn manage_incoming_message(
 
             if let Err(e) = send_to_thread(ctx, channel_id, msg, config, false).await {
                 let error = common::validation_failed(&format!("Failed to forward message: {}", e));
-                let _ = error_handler.reply_with_error(ctx, msg, &error).await;
+                let _ = error_handler
+                    .reply_to_msg_with_error(ctx, msg, &error)
+                    .await;
                 return Err(error);
             }
         }
@@ -154,7 +158,9 @@ impl EventHandler for GuildMessagesHandler {
         if msg.guild_id.is_none() {
             if let Err(error) = manage_incoming_message(&ctx, &msg, &self.config).await {
                 if let Some(error_handler) = &self.config.error_handler {
-                    let _ = error_handler.reply_with_error(&ctx, &msg, &error).await;
+                    let _ = error_handler
+                        .reply_to_msg_with_error(&ctx, &msg, &error)
+                        .await;
                 } else {
                     eprintln!("DM handling error: {}", error);
                 }
@@ -175,7 +181,9 @@ impl EventHandler for GuildMessagesHandler {
                     command_func(ctx.clone(), msg.clone(), self.config.clone()).await
             {
                 if let Some(error_handler) = &self.config.error_handler {
-                    let _ = error_handler.reply_with_error(&ctx, &msg, &error).await;
+                    let _ = error_handler
+                        .reply_to_msg_with_error(&ctx, &msg, &error)
+                        .await;
                 } else {
                     eprintln!("Command error: {}", error);
                 }

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -1,3 +1,4 @@
+use crate::commands;
 use crate::config::Config;
 use crate::features::sync_features;
 use crate::modules::message_recovery::{recover_missing_messages, send_recovery_summary};
@@ -7,7 +8,6 @@ use serenity::{
     all::{Context, EventHandler, Ready},
     async_trait,
 };
-use crate ::commands;
 
 #[derive(Clone)]
 pub struct ReadyHandler {
@@ -41,11 +41,11 @@ impl EventHandler for ReadyHandler {
 
         let guild_id = GuildId::new(self.config.bot.get_staff_guild_id());
 
-        let commands = guild_id.set_commands(&ctx.http, vec![
-            commands::id::register(),
-            commands::move_thread::register(),
-        ]).await;
-
-        println!("I now have the following guild slash commands: {commands:#?}");
+        let _ = guild_id
+            .set_commands(
+                &ctx.http,
+                vec![commands::id::register(), commands::move_thread::register()],
+            )
+            .await;
     }
 }

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -67,6 +67,10 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
             .with_help("Use `{prefix}help` to see available commands"),
     );
     dict.messages.insert(
+        "command.unknown_slash_command".to_string(),
+        DictionaryMessage::new("Unknown Slash Command: {command}"),
+    );
+    dict.messages.insert(
         "command.insufficient_permissions".to_string(),
         DictionaryMessage::new("Insufficient permissions")
             .with_description("You don't have the required permissions to use this command"),
@@ -98,6 +102,10 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "thread.modal_invalid_user_id".to_string(),
         DictionaryMessage::new("Invalid user ID"),
+    );
+    dict.messages.insert(
+        "thread.category_not_found".to_string(),
+        DictionaryMessage::new("Category not found in the server."),
     );
     dict.messages.insert(
         "message.not_found".to_string(),

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -65,6 +65,10 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
             .with_help("Utilisez `{prefix}help` pour voir les commandes disponibles"),
     );
     dict.messages.insert(
+        "command.unknown_slash_command".to_string(),
+        DictionaryMessage::new("Slash Commande inconnue : {command}"),
+    );
+    dict.messages.insert(
         "command.insufficient_permissions".to_string(),
         DictionaryMessage::new("Permissions insuffisantes").with_description(
             "Vous n'avez pas les permissions requises pour utiliser cette commande",
@@ -214,6 +218,12 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "thread.modal_user_not_found".to_string(),
         DictionaryMessage::new(
             "L'utilisateur spécifié est introuvable, veuillez en choisir un autre.",
+        ),
+    );
+    dict.messages.insert(
+        "thread.category_not_found".to_string(),
+        DictionaryMessage::new(
+            "La catégorie spécifiée pour les tickets n'existe pas sur le serveur.",
         ),
     );
     dict.messages.insert(

--- a/src/modules/threads.rs
+++ b/src/modules/threads.rs
@@ -115,7 +115,9 @@ pub async fn create_channel(ctx: &Context, msg: &Message, config: &Config) {
 
         let error = validation_failed(&error_msg);
         if let Some(error_handler) = &config.error_handler {
-            let _ = error_handler.reply_with_error(ctx, msg, &error).await;
+            let _ = error_handler
+                .reply_to_msg_with_error(ctx, msg, &error)
+                .await;
         }
         return;
     }


### PR DESCRIPTION
This pull request introduces significant improvements to error handling and command response mechanisms for slash commands, particularly for the `id` and `move` commands. The changes refactor command execution to return structured error types instead of plain strings, unify error reporting for both message and interaction contexts, and expand the error type system for better specificity and user feedback.

Key changes include:

**1. Command Execution and Error Handling Refactor**
- Refactored the `id` and `move_thread` command handlers to return `ModmailResult<()>` instead of `String`, enabling structured error propagation and consistent error handling for slash commands. User-facing responses are now sent via Discord interaction responses, and errors are surfaced through a centralized error handler. [[1]](diffhunk://#diff-c1dcc919406384abe34f07d35200ac7dd4dd40a4939d5f9a9e4d1b9599252fb8L4-R57) [[2]](diffhunk://#diff-8b431e841296bf68b8ad51192a7ffaa29cd517ae33b8fad8f2cc5f2b1fc5f14eL3-R106) [[3]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14L49-R75)

**2. Expanded Error Type System**
- Added new variants to error enums for more precise error reporting, including `UnknownSlashCommand` and `NotInThread` in `CommandError`, `CategoryNotFound` in `ThreadError`, and `FailedToFetchCategories` and `FailedToMoveChannel` in `DiscordError`. Display implementations and dictionary mappings were updated accordingly. [[1]](diffhunk://#diff-60dc83953287510220f19de0373f6d619ff1084d603ff3961371a35f16b810f5R66-R71) [[2]](diffhunk://#diff-60dc83953287510220f19de0373f6d619ff1084d603ff3961371a35f16b810f5R87) [[3]](diffhunk://#diff-60dc83953287510220f19de0373f6d619ff1084d603ff3961371a35f16b810f5R56-R57) [[4]](diffhunk://#diff-ac7d5fb4b563b4ef69771da73836f2aedac4f24f9df7b6cb40ef126a39c28344R216-R220) [[5]](diffhunk://#diff-ac7d5fb4b563b4ef69771da73836f2aedac4f24f9df7b6cb40ef126a39c28344R232) [[6]](diffhunk://#diff-60dc83953287510220f19de0373f6d619ff1084d603ff3961371a35f16b810f5R186-R187) [[7]](diffhunk://#diff-60dc83953287510220f19de0373f6d619ff1084d603ff3961371a35f16b810f5R199-R206) [[8]](diffhunk://#diff-60dc83953287510220f19de0373f6d619ff1084d603ff3961371a35f16b810f5R228)

**3. Centralized Error Reporting for Interactions**
- Introduced `reply_to_command_with_error` in the error handler to send error messages as Discord interaction responses (embeds) for slash commands. The error handler now has distinct methods for replying to messages and commands, and all command errors are routed through these methods for consistency. [[1]](diffhunk://#diff-6951ddbbdf66bb953f3f2a39783d8fe748740bd14faa49ae81307cd3807af308L132-R136) [[2]](diffhunk://#diff-6951ddbbdf66bb953f3f2a39783d8fe748740bd14faa49ae81307cd3807af308R152-R177) [[3]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14L49-R75)

**4. Improved Error Handling Macros and Utilities**
- Updated macros and internal utilities to use the new error handler methods, ensuring all errors encountered during command execution are reported to the user in the correct context (message or interaction). [[1]](diffhunk://#diff-6951ddbbdf66bb953f3f2a39783d8fe748740bd14faa49ae81307cd3807af308L384-R416) [[2]](diffhunk://#diff-6951ddbbdf66bb953f3f2a39783d8fe748740bd14faa49ae81307cd3807af308L413-R447) [[3]](diffhunk://#diff-6d87c5027c68b4ed3f04431668af30bd3ecc533091ffda3effb14f58dd2db796L242-R244)

**5. Minor Code Quality and Usability Improvements**
- Enhanced code readability and maintainability by cleaning up imports, improving parameter extraction, and making minor formatting adjustments. [[1]](diffhunk://#diff-8b431e841296bf68b8ad51192a7ffaa29cd517ae33b8fad8f2cc5f2b1fc5f14eL222-R212) [[2]](diffhunk://#diff-6951ddbbdf66bb953f3f2a39783d8fe748740bd14faa49ae81307cd3807af308L5-R9)

These changes provide a more robust, user-friendly, and maintainable framework for handling errors and responses in both traditional and slash command contexts.