### PR TITLE
feat(commands): add complete slash command for close command

### DIFF
--- a/src/commands/close/common.rs
+++ b/src/commands/close/common.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+pub fn parse_duration_spec(spec: &str) -> Option<Duration> {
+    if spec.is_empty() {
+        return None;
+    }
+    let mut total: u64 = 0;
+    let mut num: u64 = 0;
+    let mut has_unit_segment = false;
+    for ch in spec.chars() {
+        if ch.is_ascii_digit() {
+            let digit = ch.to_digit(10)? as u64;
+            num = num.saturating_mul(10).saturating_add(digit);
+        } else {
+            let unit_secs = match ch {
+                's' | 'S' => 1,
+                'm' | 'M' => 60,
+                'h' | 'H' => 3600,
+                'd' | 'D' => 86400,
+                _ => return None,
+            };
+            total = total.saturating_add(num.saturating_mul(unit_secs));
+            num = 0;
+            has_unit_segment = true;
+        }
+    }
+    if num > 0 {
+        if has_unit_segment {
+            total = total.saturating_add(num);
+        } else {
+            total = total.saturating_add(num * 60);
+        }
+    }
+    if total == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(total))
+    }
+}

--- a/src/commands/close/mod.rs
+++ b/src/commands/close/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod slash_command;
+pub mod text_command;

--- a/src/commands/close/slash_command/close.rs
+++ b/src/commands/close/slash_command/close.rs
@@ -1,137 +1,122 @@
+use crate::commands::close::common::parse_duration_spec;
+use crate::config::Config;
+use crate::db::{
+    close_thread, delete_scheduled_closure, get_scheduled_closure, upsert_scheduled_closure,
+};
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::i18n::get_translated_message;
 use crate::utils::message::message_builder::MessageBuilder;
 use crate::utils::thread::fetch_thread::fetch_thread;
-use crate::{
-    config::Config,
-    db::{close_thread, delete_scheduled_closure, get_scheduled_closure, upsert_scheduled_closure},
-    errors::{CommandError, ModmailError, ModmailResult, common},
-};
 use chrono::Utc;
-use serenity::all::{Context, GuildId, Message, UserId};
+use serenity::all::{
+    CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand,
+    CreateCommandOption, CreateInteractionResponse, GuildId, ResolvedOption, UserId,
+};
 use std::collections::HashMap;
-use tokio::time::{Duration, sleep};
+use std::time::Duration;
+use tokio::time::sleep;
 
-fn parse_duration_spec(spec: &str) -> Option<Duration> {
-    if spec.is_empty() {
-        return None;
-    }
-    let mut total: u64 = 0;
-    let mut num: u64 = 0;
-    let mut has_unit_segment = false;
-    for ch in spec.chars() {
-        if ch.is_ascii_digit() {
-            let digit = ch.to_digit(10)? as u64;
-            num = num.saturating_mul(10).saturating_add(digit);
-        } else {
-            let unit_secs = match ch {
-                's' | 'S' => 1,
-                'm' | 'M' => 60,
-                'h' | 'H' => 3600,
-                'd' | 'D' => 86400,
-                _ => return None,
-            };
-            total = total.saturating_add(num.saturating_mul(unit_secs));
-            num = 0;
-            has_unit_segment = true;
-        }
-    }
-    if num > 0 {
-        if has_unit_segment {
-            total = total.saturating_add(num);
-        } else {
-            total = total.saturating_add(num * 60);
-        }
-    }
-    if total == 0 {
-        None
-    } else {
-        Some(Duration::from_secs(total))
-    }
+pub async fn register(config: &Config) -> CreateCommand {
+    let cmd_desc = get_translated_message(
+        config,
+        "slash_command.close_command_description",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    CreateCommand::new("close").description(cmd_desc).add_option(
+        CreateCommandOption::new(
+            CommandOptionType::String, "time_before_close", "Duration before the thread is closed (e.g., 10m, 1h, 2d). Defaults the thread is closed immediately.")
+            .required(false)
+    ).add_option(
+        CreateCommandOption::new(
+            CommandOptionType::Boolean, "silent", "If set, the user will not be notified when the thread is closed.")
+            .required(false)
+    ).add_option(
+        CreateCommandOption::new(
+            CommandOptionType::Boolean, "cancel", "If set, cancels any scheduled closure for this thread.")
+            .required(false)
+    )
 }
 
-pub async fn close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
+pub async fn run(
+    ctx: &Context,
+    command: &CommandInteraction,
+    _options: &[ResolvedOption<'_>],
+    config: &Config,
+) -> ModmailResult<()> {
     let db_pool = config
         .db_pool
         .as_ref()
         .ok_or_else(common::database_connection_failed)?;
 
-    let content = msg.content.trim();
-    let prefix = &config.command.prefix;
-    let command_name = "close";
-    if !content.starts_with(&format!("{}{}", prefix, command_name)) {
-        return Err(ModmailError::Command(CommandError::UnknownCommand(
-            command_name.to_string(),
-        )));
-    }
-    let args_part = content[prefix.len() + command_name.len()..].trim();
-
-    let mut silent = false;
+    let mut time_before_close: Option<String> = None;
+    let mut silent: Option<bool> = None;
+    let mut cancel: Option<bool> = None;
     let mut duration: Option<Duration> = None;
-    let mut cancel = false;
-    if !args_part.is_empty() {
-        let tokens: Vec<&str> = args_part.split_whitespace().collect();
-        for &tok in &tokens {
-            if tok.eq_ignore_ascii_case("-s") || tok.eq_ignore_ascii_case("--silent") {
-                silent = true;
-                continue;
-            }
-            if tok.eq_ignore_ascii_case("cancel")
-                || tok.eq_ignore_ascii_case("-c")
-                || tok.eq_ignore_ascii_case("--cancel")
-            {
-                cancel = true;
-                continue;
-            }
-            if duration.is_none() {
-                if let Some(dur) = parse_duration_spec(tok) {
-                    duration = Some(dur);
-                    continue;
-                } else {
-                    return Err(ModmailError::Command(CommandError::InvalidArguments(
-                        tok.to_string(),
-                    )));
+
+    for option in &command.data.options {
+        match option.name.as_str() {
+            "time_before_close" => {
+                if let CommandDataOptionValue::String(val) = &option.value {
+                    time_before_close.replace(val.clone());
                 }
-            } else {
-                return Err(ModmailError::Command(CommandError::InvalidArguments(
-                    tok.to_string(),
-                )));
             }
+            "silent" => {
+                if let CommandDataOptionValue::Boolean(val) = &option.value {
+                    silent.replace(*val);
+                }
+            }
+            "cancel" => {
+                if let CommandDataOptionValue::Boolean(val) = &option.value {
+                    cancel.replace(*val);
+                }
+            }
+            _ => {}
         }
     }
 
-    let thread = fetch_thread(db_pool, &msg.channel_id.to_string()).await?;
+    if let Some(time_before_close) = time_before_close {
+        if let Some(dur) = parse_duration_spec(&time_before_close) {
+            duration = Some(dur);
+        }
+    }
+
+    let thread = fetch_thread(db_pool, &command.channel_id.to_string()).await?;
     let user_id = UserId::new(thread.user_id as u64);
     let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
 
-    if cancel {
+    if let Some(cancel) = cancel
+        && cancel
+    {
         let existed = delete_scheduled_closure(&thread.id, db_pool)
             .await
             .unwrap_or(false);
-        if existed {
-            let _ = MessageBuilder::system_message(ctx, config)
+        return if existed {
+            let response = MessageBuilder::system_message(ctx, config)
                 .translated_content(
                     "close.closure_canceled",
                     None,
-                    Some(msg.author.id),
-                    msg.guild_id.map(|g| g.get()),
+                    Some(command.user.id),
+                    command.guild_id.map(|g| g.get()),
                 )
                 .await
-                .to_channel(msg.channel_id)
-                .send()
+                .to_channel(command.channel_id)
+                .build_interaction_message()
                 .await;
+
+            let _ = command
+                .create_response(&ctx.http, CreateInteractionResponse::Message(response))
+                .await;
+            Ok(())
         } else {
-            let _ = MessageBuilder::system_message(ctx, config)
-                .translated_content(
-                    "close.no_scheduled_closures_to_cancel",
-                    None,
-                    Some(msg.author.id),
-                    msg.guild_id.map(|g| g.get()),
-                )
-                .await
-                .to_channel(msg.channel_id)
-                .send()
-                .await;
-        }
-        return Ok(());
+            Err(ModmailError::Command(
+                CommandError::NoSchedulableClosureToCancel,
+            ))
+        };
     }
 
     if duration.is_none() {
@@ -142,18 +127,7 @@ pub async fn close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResu
             params.insert("seconds".to_string(), remaining.to_string());
 
             if remaining > 0 {
-                let _ = MessageBuilder::system_message(ctx, config)
-                    .translated_content(
-                        "close.closure_already_scheduled",
-                        Some(&params),
-                        Some(msg.author.id),
-                        msg.guild_id.map(|g| g.get()),
-                    )
-                    .await
-                    .to_channel(msg.channel_id)
-                    .send()
-                    .await;
-                return Ok(());
+                return Err(ModmailError::Command(CommandError::ClosureAlreadyScheduled));
             }
         }
     }
@@ -172,38 +146,49 @@ pub async fn close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResu
         let mut params = HashMap::new();
         params.insert("time".to_string(), human);
 
-        let _ = if silent {
-            let _ = MessageBuilder::system_message(ctx, config)
+        let _ = if let Some(silent) = silent
+            && silent
+        {
+            let response = MessageBuilder::system_message(ctx, config)
                 .translated_content(
                     "close.silent_closing",
                     Some(&params),
-                    Some(msg.author.id),
-                    msg.guild_id.map(|g| g.get()),
+                    Some(command.user.id),
+                    command.guild_id.map(|g| g.get()),
                 )
                 .await
-                .to_channel(msg.channel_id)
-                .send()
+                .to_channel(command.channel_id)
+                .build_interaction_message()
+                .await;
+
+            let _ = command
+                .create_response(&ctx.http, CreateInteractionResponse::Message(response))
                 .await;
         } else {
-            let _ = MessageBuilder::system_message(ctx, config)
+            let response = MessageBuilder::system_message(ctx, config)
                 .translated_content(
                     "close.closing",
                     Some(&params),
-                    Some(msg.author.id),
-                    msg.guild_id.map(|g| g.get()),
+                    Some(command.user.id),
+                    command.guild_id.map(|g| g.get()),
                 )
                 .await
-                .to_channel(msg.channel_id)
-                .send()
+                .to_channel(command.channel_id)
+                .build_interaction_message()
+                .await;
+
+            let _ = command
+                .create_response(&ctx.http, CreateInteractionResponse::Message(response))
                 .await;
         };
 
         let thread_id = thread.id.clone();
         let close_at = Utc::now().timestamp() + delay.as_secs() as i64;
+        let silent = silent.unwrap_or(false);
         if let Err(e) = upsert_scheduled_closure(&thread_id, close_at, silent, db_pool).await {
             eprintln!("Failed to persist scheduled closure: {e:?}");
         }
-        let channel_id = msg.channel_id;
+        let channel_id = command.channel_id;
         let config_clone = config.clone();
         let ctx_clone = ctx.clone();
         let user_id_clone = user_id;
@@ -280,7 +265,10 @@ pub async fn close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResu
 
     let user_still_member = community_guild_id.member(&ctx.http, user_id).await.is_ok();
 
-    if user_still_member && !silent {
+    if user_still_member
+        && let Some(silent) = silent
+        && !silent
+    {
         let _ = MessageBuilder::system_message(ctx, config)
             .content(&config.bot.close_message)
             .to_user(user_id)
@@ -290,23 +278,27 @@ pub async fn close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResu
         let mut params = HashMap::new();
         params.insert("username".to_string(), thread.user_name.clone());
 
-        let _ = MessageBuilder::system_message(ctx, config)
+        let response = MessageBuilder::system_message(ctx, config)
             .translated_content(
                 "user.left_server_close",
                 Some(&params),
-                Some(msg.author.id),
-                msg.guild_id.map(|g| g.get()),
+                Some(command.user.id),
+                command.guild_id.map(|g| g.get()),
             )
             .await
-            .to_channel(msg.channel_id)
-            .send()
+            .to_channel(command.channel_id)
+            .build_interaction_message()
+            .await;
+
+        let _ = command
+            .create_response(&ctx.http, CreateInteractionResponse::Message(response))
             .await;
     }
 
     close_thread(&thread.id, db_pool).await?;
     let _ = delete_scheduled_closure(&thread.id, db_pool).await;
 
-    let _ = msg.channel_id.delete(&ctx.http).await?;
+    let _ = command.channel_id.delete(&ctx.http).await?;
 
     Ok(())
 }

--- a/src/commands/close/slash_command/mod.rs
+++ b/src/commands/close/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod close;

--- a/src/commands/close/text_command/close.rs
+++ b/src/commands/close/text_command/close.rs
@@ -1,0 +1,276 @@
+use crate::commands::close::common::parse_duration_spec;
+use crate::config::Config;
+use crate::db::{
+    close_thread, delete_scheduled_closure, get_scheduled_closure, upsert_scheduled_closure,
+};
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::utils::message::message_builder::MessageBuilder;
+use crate::utils::thread::fetch_thread::fetch_thread;
+use chrono::Utc;
+use serenity::all::{Context, GuildId, Message, UserId};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::sleep;
+
+pub async fn close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
+    let db_pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(common::database_connection_failed)?;
+
+    let content = msg.content.trim();
+    let prefix = &config.command.prefix;
+    let command_name = "close";
+    if !content.starts_with(&format!("{}{}", prefix, command_name)) {
+        return Err(ModmailError::Command(CommandError::UnknownCommand(
+            command_name.to_string(),
+        )));
+    }
+    let args_part = content[prefix.len() + command_name.len()..].trim();
+
+    let mut silent = false;
+    let mut duration: Option<Duration> = None;
+    let mut cancel = false;
+    if !args_part.is_empty() {
+        let tokens: Vec<&str> = args_part.split_whitespace().collect();
+        for &tok in &tokens {
+            if tok.eq_ignore_ascii_case("-s") || tok.eq_ignore_ascii_case("--silent") {
+                silent = true;
+                continue;
+            }
+            if tok.eq_ignore_ascii_case("cancel")
+                || tok.eq_ignore_ascii_case("-c")
+                || tok.eq_ignore_ascii_case("--cancel")
+            {
+                cancel = true;
+                continue;
+            }
+            if duration.is_none() {
+                if let Some(dur) = parse_duration_spec(tok) {
+                    duration = Some(dur);
+                    continue;
+                } else {
+                    return Err(ModmailError::Command(CommandError::InvalidArguments(
+                        tok.to_string(),
+                    )));
+                }
+            } else {
+                return Err(ModmailError::Command(CommandError::InvalidArguments(
+                    tok.to_string(),
+                )));
+            }
+        }
+    }
+
+    let thread = fetch_thread(db_pool, &msg.channel_id.to_string()).await?;
+    let user_id = UserId::new(thread.user_id as u64);
+    let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
+
+    if cancel {
+        let existed = delete_scheduled_closure(&thread.id, db_pool)
+            .await
+            .unwrap_or(false);
+        if existed {
+            let _ = MessageBuilder::system_message(ctx, config)
+                .translated_content(
+                    "close.closure_canceled",
+                    None,
+                    Some(msg.author.id),
+                    msg.guild_id.map(|g| g.get()),
+                )
+                .await
+                .to_channel(msg.channel_id)
+                .send()
+                .await;
+        } else {
+            let _ = MessageBuilder::system_message(ctx, config)
+                .translated_content(
+                    "close.no_scheduled_closures_to_cancel",
+                    None,
+                    Some(msg.author.id),
+                    msg.guild_id.map(|g| g.get()),
+                )
+                .await
+                .to_channel(msg.channel_id)
+                .send()
+                .await;
+        }
+        return Ok(());
+    }
+
+    if duration.is_none() {
+        if let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await {
+            let remaining = existing.close_at - Utc::now().timestamp();
+
+            let mut params = HashMap::new();
+            params.insert("seconds".to_string(), remaining.to_string());
+
+            if remaining > 0 {
+                let _ = MessageBuilder::system_message(ctx, config)
+                    .translated_content(
+                        "close.closure_already_scheduled",
+                        Some(&params),
+                        Some(msg.author.id),
+                        msg.guild_id.map(|g| g.get()),
+                    )
+                    .await
+                    .to_channel(msg.channel_id)
+                    .send()
+                    .await;
+                return Ok(());
+            }
+        }
+    }
+
+    if let Some(delay) = duration {
+        let delay_secs = delay.as_secs();
+        let human = if delay_secs < 60 {
+            format!("{}s", delay_secs)
+        } else if delay_secs < 3600 {
+            format!("{}m", delay_secs / 60)
+        } else if delay_secs < 86400 {
+            format!("{}h{}m", delay_secs / 3600, (delay_secs % 3600) / 60)
+        } else {
+            format!("{}d{}h", delay_secs / 86400, (delay_secs % 86400) / 3600)
+        };
+        let mut params = HashMap::new();
+        params.insert("time".to_string(), human);
+
+        let _ = if silent {
+            let _ = MessageBuilder::system_message(ctx, config)
+                .translated_content(
+                    "close.silent_closing",
+                    Some(&params),
+                    Some(msg.author.id),
+                    msg.guild_id.map(|g| g.get()),
+                )
+                .await
+                .to_channel(msg.channel_id)
+                .send()
+                .await;
+        } else {
+            let _ = MessageBuilder::system_message(ctx, config)
+                .translated_content(
+                    "close.closing",
+                    Some(&params),
+                    Some(msg.author.id),
+                    msg.guild_id.map(|g| g.get()),
+                )
+                .await
+                .to_channel(msg.channel_id)
+                .send()
+                .await;
+        };
+
+        let thread_id = thread.id.clone();
+        let close_at = Utc::now().timestamp() + delay.as_secs() as i64;
+        if let Err(e) = upsert_scheduled_closure(&thread_id, close_at, silent, db_pool).await {
+            eprintln!("Failed to persist scheduled closure: {e:?}");
+        }
+        let channel_id = msg.channel_id;
+        let config_clone = config.clone();
+        let ctx_clone = ctx.clone();
+        let user_id_clone = user_id;
+        let thread_id_for_task = thread_id.clone();
+
+        tokio::spawn(async move {
+            sleep(delay).await;
+            if let Some(pool) = config_clone.db_pool.as_ref() {
+                if let Ok(Some(record)) = get_scheduled_closure(&thread_id_for_task, pool).await {
+                    if record.close_at <= Utc::now().timestamp() {
+                        let _ = close_thread(&thread_id_for_task, pool).await;
+                        let _ = delete_scheduled_closure(&thread_id_for_task, pool).await;
+
+                        let community_guild_id =
+                            GuildId::new(config_clone.bot.get_community_guild_id());
+
+                        let user_still_member = community_guild_id
+                            .member(&ctx_clone.http, user_id_clone)
+                            .await
+                            .is_ok();
+
+                        if !record.silent && user_still_member {
+                            let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
+                                .content(&config_clone.bot.close_message)
+                                .to_user(user_id_clone)
+                                .send()
+                                .await;
+                        }
+                        let _ = channel_id.delete(&ctx_clone.http).await;
+                    } else {
+                        let delay2 = (record.close_at - Utc::now().timestamp()).max(1) as u64;
+                        let config_clone2 = config_clone.clone();
+                        let ctx_clone2 = ctx_clone.clone();
+                        let thread_id_again = thread_id_for_task.clone();
+
+                        tokio::spawn(async move {
+                            sleep(Duration::from_secs(delay2)).await;
+                            if let Some(pool2) = config_clone2.db_pool.as_ref() {
+                                if let Ok(Some(r2)) =
+                                    get_scheduled_closure(&thread_id_again, pool2).await
+                                {
+                                    if r2.close_at <= Utc::now().timestamp() {
+                                        let _ = close_thread(&thread_id_again, pool2).await;
+                                        let _ =
+                                            delete_scheduled_closure(&thread_id_again, pool2).await;
+                                        let community_guild_id = GuildId::new(
+                                            config_clone2.bot.get_community_guild_id(),
+                                        );
+                                        let user_still_member = community_guild_id
+                                            .member(&ctx_clone2.http, user_id_clone)
+                                            .await
+                                            .is_ok();
+                                        if !r2.silent && user_still_member {
+                                            let _ = MessageBuilder::system_message(
+                                                &ctx_clone2,
+                                                &config_clone2,
+                                            )
+                                            .content(&config_clone2.bot.close_message)
+                                            .to_user(user_id_clone)
+                                            .send()
+                                            .await;
+                                        }
+                                        let _ = channel_id.delete(&ctx_clone2.http).await;
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+        });
+        return Ok(());
+    }
+
+    let user_still_member = community_guild_id.member(&ctx.http, user_id).await.is_ok();
+
+    if user_still_member && !silent {
+        let _ = MessageBuilder::system_message(ctx, config)
+            .content(&config.bot.close_message)
+            .to_user(user_id)
+            .send()
+            .await;
+    } else if !user_still_member {
+        let mut params = HashMap::new();
+        params.insert("username".to_string(), thread.user_name.clone());
+
+        let _ = MessageBuilder::system_message(ctx, config)
+            .translated_content(
+                "user.left_server_close",
+                Some(&params),
+                Some(msg.author.id),
+                msg.guild_id.map(|g| g.get()),
+            )
+            .await
+            .to_channel(msg.channel_id)
+            .send()
+            .await;
+    }
+
+    close_thread(&thread.id, db_pool).await?;
+    let _ = delete_scheduled_closure(&thread.id, db_pool).await;
+
+    let _ = msg.channel_id.delete(&ctx.http).await?;
+
+    Ok(())
+}

--- a/src/commands/close/text_command/mod.rs
+++ b/src/commands/close/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod close;

--- a/src/commands/id/slash_command/id.rs
+++ b/src/commands/id/slash_command/id.rs
@@ -3,13 +3,21 @@ use crate::db::get_thread_by_channel_id;
 use crate::db::threads::is_a_ticket_channel;
 use crate::errors::ThreadError::{NotAThreadChannel, ThreadNotFound};
 use crate::errors::{DatabaseError, ModmailError, ModmailResult};
+use crate::i18n::get_translated_message;
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::{CommandInteraction, Context, ResolvedOption};
 use serenity::builder::{CreateCommand, CreateInteractionResponse};
-use crate::i18n::get_translated_message;
 
 pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(config, "slash_command.id_command_description", None, None, None, None).await;
+    let cmd_desc = get_translated_message(
+        config,
+        "slash_command.id_command_description",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     CreateCommand::new("id").description(cmd_desc)
 }

--- a/src/commands/move_thread/slash_command/move_thread.rs
+++ b/src/commands/move_thread/slash_command/move_thread.rs
@@ -34,16 +34,10 @@ pub async fn register(config: &Config) -> CreateCommand {
     )
     .await;
 
-    CreateCommand::new("move")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(
-                CommandOptionType::String,
-                "category",
-                catagory_field_desc,
-            )
+    CreateCommand::new("move").description(cmd_desc).add_option(
+        CreateCommandOption::new(CommandOptionType::String, "category", catagory_field_desc)
             .required(true),
-        )
+    )
 }
 
 pub async fn run(

--- a/src/commands/new_thread/slash_command/new_thread.rs
+++ b/src/commands/new_thread/slash_command/new_thread.rs
@@ -1,12 +1,17 @@
-use std::collections::HashMap;
+use crate::commands::new_thread::common::send_welcome_message;
 use crate::config::Config;
-use crate::i18n::get_translated_message;
-use serenity::all::{ChannelId, CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand, CreateCommandOption, GuildId, ResolvedOption, UserId};
-use serenity::builder::CreateInteractionResponse;
-use crate::commands::new_thread::common::{send_welcome_message};
 use crate::db::{create_thread_for_user, get_thread_channel_by_user_id, thread_exists};
-use crate::errors::{common, CommandError, DatabaseError, DiscordError, ModmailError, ModmailResult};
+use crate::errors::{
+    CommandError, DatabaseError, DiscordError, ModmailError, ModmailResult, common,
+};
+use crate::i18n::get_translated_message;
 use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{
+    ChannelId, CommandDataOptionValue, CommandInteraction, CommandOptionType, Context,
+    CreateCommand, CreateCommandOption, GuildId, ResolvedOption, UserId,
+};
+use serenity::builder::CreateInteractionResponse;
+use std::collections::HashMap;
 
 pub async fn register(config: &Config) -> CreateCommand {
     let cmd_desc = get_translated_message(
@@ -27,7 +32,7 @@ pub async fn register(config: &Config) -> CreateCommand {
         None,
         None,
     )
-        .await;
+    .await;
 
     CreateCommand::new("new_thread")
         .description(cmd_desc)
@@ -56,16 +61,18 @@ pub async fn run(
     {
         Some(opt) => match &opt.value {
             CommandDataOptionValue::User(user_id) => *user_id,
-            _ => return Err(ModmailError::Command(CommandError::InvalidArguments("user_id".to_string()))),
+            _ => {
+                return Err(ModmailError::Command(CommandError::InvalidArguments(
+                    "user_id".to_string(),
+                )));
+            }
         },
         None => return Err(ModmailError::Command(CommandError::MissingArguments)),
     };
 
     let user = match ctx.http.get_user(user_id).await {
         Ok(user) => user,
-        Err(_) => {
-            return Err(ModmailError::Discord(DiscordError::UserNotFound))
-        }
+        Err(_) => return Err(ModmailError::Discord(DiscordError::UserNotFound)),
     };
 
     if user.bot {
@@ -74,7 +81,12 @@ pub async fn run(
 
     if thread_exists(user_id, pool).await {
         return if let Some(channel_id_str) = get_thread_channel_by_user_id(user_id, pool).await {
-            Err(ModmailError::Command(CommandError::UserHasAlreadyAThreadWithLink(user.name.clone(), channel_id_str.clone())))
+            Err(ModmailError::Command(
+                CommandError::UserHasAlreadyAThreadWithLink(
+                    user.name.clone(),
+                    channel_id_str.clone(),
+                ),
+            ))
         } else {
             Err(ModmailError::Command(CommandError::UserHasAlreadyAThread()))
         };
@@ -106,7 +118,9 @@ pub async fn run(
         Err(e) => {
             eprintln!("Failed to create thread in database: {}", e);
             let _ = guild_channel.delete(&ctx.http).await;
-            return Err(ModmailError::Database(DatabaseError::InsertFailed(e.to_string())));
+            return Err(ModmailError::Database(DatabaseError::InsertFailed(
+                e.to_string(),
+            )));
         }
     };
 
@@ -117,14 +131,19 @@ pub async fn run(
     params.insert("channel_id".to_string(), guild_channel.to_string());
     params.insert("staff".to_string(), command.user.name.clone());
 
-    println!("Thread created for user {} in channel {}", user.name, guild_channel.to_string());
+    println!(
+        "Thread created for user {} in channel {}",
+        user.name,
+        guild_channel.to_string()
+    );
 
     let response = CreateInteractionResponse::Message(
         MessageBuilder::system_message(ctx, config)
-            .translated_content("new_thread.success_with_dm", Some(&params), None, None).await
+            .translated_content("new_thread.success_with_dm", Some(&params), None, None)
+            .await
             .to_channel(command.channel_id)
             .build_interaction_message()
-            .await
+            .await,
     );
 
     let _ = command.create_response(&ctx.http, response).await?;

--- a/src/commands/new_thread/text_command/new_thread.rs
+++ b/src/commands/new_thread/text_command/new_thread.rs
@@ -4,7 +4,7 @@ use crate::commands::new_thread::common::{
 };
 use crate::config::Config;
 use crate::db::{create_thread_for_user, get_thread_channel_by_user_id, thread_exists};
-use crate::errors::{ModmailResult, common, ModmailError, DiscordError};
+use crate::errors::{DiscordError, ModmailError, ModmailResult, common};
 use serenity::all::{ChannelId, Context, GuildId, Message};
 use std::collections::HashMap;
 
@@ -24,9 +24,7 @@ pub async fn new_thread(ctx: &Context, msg: &Message, config: &Config) -> Modmai
 
     let user = match ctx.http.get_user(user_id).await {
         Ok(user) => user,
-        Err(_) => {
-            return Err(ModmailError::Discord(DiscordError::UserNotFound))
-        }
+        Err(_) => return Err(ModmailError::Discord(DiscordError::UserNotFound)),
     };
 
     if user.bot {

--- a/src/errors/dictionary.rs
+++ b/src/errors/dictionary.rs
@@ -226,7 +226,16 @@ impl DictionaryManager {
                     let mut params = HashMap::new();
                     params.insert("user".to_string(), user.clone());
                     params.insert("channel_id".to_string(), channel_id.clone());
-                    ("command.user_has_thread_with_link".to_string(), Some(params))
+                    (
+                        "new_thread.user_has_thread_with_link".to_string(),
+                        Some(params),
+                    )
+                }
+                CommandError::ClosureAlreadyScheduled => {
+                    ("close.closure_already_scheduled".to_string(), None)
+                }
+                CommandError::NoSchedulableClosureToCancel => {
+                    ("close.no_scheduled_closures_to_cancel".to_string(), None)
                 }
                 _ => ("command.invalid_format".to_string(), None),
             },

--- a/src/errors/types.rs
+++ b/src/errors/types.rs
@@ -72,6 +72,8 @@ pub enum CommandError {
     NotInThread(),
     UserHasAlreadyAThread(),
     UserHasAlreadyAThreadWithLink(String, String),
+    ClosureAlreadyScheduled,
+    NoSchedulableClosureToCancel,
 }
 
 #[derive(Debug, Clone)]
@@ -208,8 +210,20 @@ impl fmt::Display for CommandError {
                 write!(f, "Cooldown active: {} seconds", seconds)
             }
             CommandError::NotInThread() => write!(f, "This command can only be used in a thread"),
-            CommandError::UserHasAlreadyAThread() => write!(f, "The user already has an open thread"),
-            CommandError::UserHasAlreadyAThreadWithLink(user, channel_id) => write!(f, "The user {} already has an open thread: {}", user, channel_id),
+            CommandError::UserHasAlreadyAThread() => {
+                write!(f, "The user already has an open thread")
+            }
+            CommandError::UserHasAlreadyAThreadWithLink(user, channel_id) => write!(
+                f,
+                "The user {} already has an open thread: {}",
+                user, channel_id
+            ),
+            CommandError::ClosureAlreadyScheduled => {
+                write!(f, "Thread closure is already scheduled")
+            }
+            CommandError::NoSchedulableClosureToCancel => {
+                write!(f, "No schedulable closure to cancel")
+            }
         }
     }
 }

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -1,6 +1,9 @@
-use std::clone;
+use crate::commands::close::slash_command::close;
+use crate::commands::close::text_command::close::close;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
+use crate::commands::new_thread::slash_command::new_thread;
+use crate::commands::new_thread::text_command::new_thread::new_thread;
 use crate::config::Config;
 use crate::errors::{CommandError, ModmailError};
 use crate::features::handle_feature_component_interaction;
@@ -9,8 +12,7 @@ use crate::modules::threads::{
 };
 use serenity::all::{Context, EventHandler, Interaction};
 use serenity::async_trait;
-use crate::commands::new_thread::slash_command::new_thread;
-use crate::commands::new_thread::text_command::new_thread::new_thread;
+use std::clone;
 
 #[derive(Clone)]
 pub struct InteractionHandler {
@@ -56,13 +58,10 @@ impl EventHandler for InteractionHandler {
                             .await
                     }
                     "new_thread" => {
-                        new_thread::run(
-                            &ctx,
-                            &command,
-                            &command.data.options(),
-                            &self.config,
-                        )
-                        .await
+                        new_thread::run(&ctx, &command, &command.data.options(), &self.config).await
+                    }
+                    "close" => {
+                        close::run(&ctx, &command, &command.data.options(), &self.config).await
                     }
                     _ => Err(ModmailError::Command(CommandError::UnknownSlashCommand(
                         command.data.name.clone(),

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -1,13 +1,14 @@
 use crate::commands::add_staff::add_staff;
+use crate::commands::close::text_command::close::close;
 use crate::commands::edit::message_ops::edit_inbox_message;
 use crate::commands::force_close::force_close;
 use crate::commands::id::text_command::id::id;
 use crate::commands::move_thread::text_command::move_thread::move_thread;
+use crate::commands::new_thread::text_command::new_thread::new_thread;
 use crate::commands::remove_staff::remove_staff;
 use crate::commands::{
     alert::alert,
     anonreply::anonreply,
-    close::close,
     delete::delete,
     edit::edit_command::edit,
     recover::recover,
@@ -36,7 +37,6 @@ use serenity::{
 use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex};
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
-use crate::commands::new_thread::text_command::new_thread::new_thread;
 
 static SUPPRESSED_DELETES: LazyLock<Mutex<HashSet<u64>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -1,5 +1,8 @@
+use crate::commands::close::slash_command::close;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
+use crate::commands::new_thread::slash_command::new_thread;
+use crate::commands::new_thread::text_command::new_thread::new_thread;
 use crate::config::Config;
 use crate::features::sync_features;
 use crate::modules::message_recovery::{recover_missing_messages, send_recovery_summary};
@@ -9,8 +12,6 @@ use serenity::{
     all::{Context, EventHandler, Ready},
     async_trait,
 };
-use crate::commands::new_thread::slash_command::new_thread;
-use crate::commands::new_thread::text_command::new_thread::new_thread;
 
 #[derive(Clone)]
 pub struct ReadyHandler {
@@ -45,11 +46,15 @@ impl EventHandler for ReadyHandler {
         let guild_id = GuildId::new(self.config.bot.get_staff_guild_id());
 
         let _ = guild_id
-            .set_commands(&ctx.http, vec![
-                id::register(&self.config).await,
-                move_thread::register(&self.config).await,
-                new_thread::register(&self.config).await,
-            ])
+            .set_commands(
+                &ctx.http,
+                vec![
+                    id::register(&self.config).await,
+                    move_thread::register(&self.config).await,
+                    new_thread::register(&self.config).await,
+                    close::register(&self.config).await,
+                ],
+            )
             .await;
     }
 }

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -46,7 +46,7 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "discord.user_is_a_bot".to_string(),
-        DictionaryMessage::new("The specified user is a bot.")
+        DictionaryMessage::new("The specified user is a bot."),
     );
     dict.messages.insert(
         "command.invalid_format".to_string(),
@@ -632,5 +632,13 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "slash_command.new_thread_user_id_argument".to_string(),
         DictionaryMessage::new("The ID of the user to create the thread for"),
+    );
+    dict.messages.insert(
+        "slash_command.new_thread_user_id_argument".to_string(),
+        DictionaryMessage::new("The ID of the user to create the thread for"),
+    );
+    dict.messages.insert(
+        "slash_command.close_command_description".to_string(),
+        DictionaryMessage::new("Close the current thread"),
     );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -44,7 +44,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "discord.user_is_a_bot".to_string(),
-        DictionaryMessage::new("L'utilisateur spécifié est un bot")
+        DictionaryMessage::new("L'utilisateur spécifié est un bot"),
     );
     dict.messages.insert(
         "command.invalid_format".to_string(),
@@ -494,7 +494,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "new_thread.user_has_thread".to_string(),
-        DictionaryMessage::new("❌ Cet utilisateur a déjà un thread de support actif")
+        DictionaryMessage::new("❌ Cet utilisateur a déjà un thread de support actif"),
     );
     dict.messages.insert(
         "new_thread.user_has_thread_with_link".to_string(),
@@ -651,5 +651,9 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "slash_command.new_thread_user_id_argument".to_string(),
         DictionaryMessage::new("L'ID de l'utilisateur pour lequel créer le thread"),
+    );
+    dict.messages.insert(
+        "slash_command.close_command_description".to_string(),
+        DictionaryMessage::new("Fermer un ticket de support"),
     );
 }


### PR DESCRIPTION
This pull request restructures and refactors the implementation of the "close" command for both slash and text-based commands, improving code organization, reusability, and maintainability. The main logic for parsing duration specifications is now shared, and command modules are split into more granular files. Additionally, minor formatting and consistency improvements are made in other command modules.

**Close command refactor and improvements:**

* Extracted the `parse_duration_spec` function from the text command and moved it to a new shared module `src/commands/close/common.rs`, so both slash and text commands use the same duration parsing logic. [[1]](diffhunk://#diff-f18d3adfc6e1d3f1968e8f0eedd12ec19315e6d996ee517626a6d01e96ef3c62R1-R39) [[2]](diffhunk://#diff-59cb364388149f730ecfce1d87badbba0ae705845af015b7ced08e43b55ca68dR1-R13) [[3]](diffhunk://#diff-212cd7462f7654370877432450f9e3522b13e37029ff7ebaef33f23980a24130R1-R304)
* Split the "close" command into modular submodules: `common`, `slash_command`, and `text_command`, each with its own file and mod.rs, improving code organization and separation of concerns. [[1]](diffhunk://#diff-ad268edaa3149f6e528d1b3ff65c5bf05f14e43d74cb5e71dc187e6c6d9dbf72R1-R3) [[2]](diffhunk://#diff-51786e983d95b1ce4d78669c9930d205cde467f843792e3a463b8d6b303e2458R1) [[3]](diffhunk://#diff-59cb364388149f730ecfce1d87badbba0ae705845af015b7ced08e43b55ca68dR1-R13) [[4]](diffhunk://#diff-212cd7462f7654370877432450f9e3522b13e37029ff7ebaef33f23980a24130R1-R304)
* Implemented the slash command version of "close" in `src/commands/close/slash_command/close.rs`, supporting scheduling, canceling, and silent closure of threads, with asynchronous handling and user notifications.

**General code quality and consistency improvements:**

* Improved formatting, error handling, and code style in the new thread slash command module for better readability and maintainability. [[1]](diffhunk://#diff-177477395c32ad4a55b86259f5ef19ad7ac18d1d1bd7b3875be658647122de1eL1-R14) [[2]](diffhunk://#diff-177477395c32ad4a55b86259f5ef19ad7ac18d1d1bd7b3875be658647122de1eL59-R75) [[3]](diffhunk://#diff-177477395c32ad4a55b86259f5ef19ad7ac18d1d1bd7b3875be658647122de1eL77-R89) [[4]](diffhunk://#diff-177477395c32ad4a55b86259f5ef19ad7ac18d1d1bd7b3875be658647122de1eL109-R123) [[5]](diffhunk://#diff-177477395c32ad4a55b86259f5ef19ad7ac18d1d1bd7b3875be658647122de1eL120-R146)
* Minor import order and formatting corrections in other command files for consistency. [[1]](diffhunk://#diff-0ad90957db4780d0b05296965e72bb9f09546787132e48c16d958f1ee08932f0R6-R20) [[2]](diffhunk://#diff-fd3bc185b167b97f8b5582cd8bb69ee150c9db637cbf19bb6ef30f4b89e05464L37-R38) [[3]](diffhunk://#diff-33148c583b35ff9c66ae06e51903053804bbb5d922a7823bce7abd4f3aebff6bL7-R7)

These changes make the command handling codebase more modular and easier to extend or maintain in the future.