### PR TITLE
feat(commands): add complete slash command for add_staff command

### DIFF
--- a/src/commands/add_staff/common.rs
+++ b/src/commands/add_staff/common.rs
@@ -1,0 +1,43 @@
+use crate::config::Config;
+use crate::errors::ModmailResult;
+use serenity::all::{
+    ChannelId, Context, Message, PermissionOverwrite, PermissionOverwriteType, UserId,
+};
+use serenity::model::Permissions;
+
+pub async fn add_user_to_channel(
+    ctx: &Context,
+    channel_id: ChannelId,
+    user_id: UserId,
+) -> ModmailResult<()> {
+    let allow = Permissions::VIEW_CHANNEL | Permissions::SEND_MESSAGES;
+
+    channel_id
+        .create_permission(
+            &ctx.http,
+            PermissionOverwrite {
+                allow,
+                deny: Permissions::empty(),
+                kind: PermissionOverwriteType::Member(user_id),
+            },
+        )
+        .await?;
+
+    Ok(())
+}
+
+pub async fn extract_user_id(msg: &Message, config: &Config) -> String {
+    let content = msg.content.trim();
+    let prefix = &config.command.prefix;
+    let command_names = ["add_staff", "as"];
+
+    if command_names
+        .iter()
+        .any(|&name| content.starts_with(&format!("{}{}", prefix, name)))
+    {
+        let start = prefix.len() + command_names[0].len();
+        content[start..].trim().to_string()
+    } else {
+        String::new()
+    }
+}

--- a/src/commands/add_staff/mod.rs
+++ b/src/commands/add_staff/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod slash_command;
+pub mod text_command;

--- a/src/commands/add_staff/slash_command/add_staff.rs
+++ b/src/commands/add_staff/slash_command/add_staff.rs
@@ -1,0 +1,96 @@
+use crate::commands::add_staff::common::add_user_to_channel;
+use crate::config::Config;
+use crate::db::thread_exists;
+use crate::errors::CommandError::InvalidFormat;
+use crate::errors::ThreadError::NotAThreadChannel;
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::i18n::get_translated_message;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{
+    CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand,
+    CreateCommandOption, ResolvedOption,
+};
+use serenity::builder::CreateInteractionResponse;
+use std::collections::HashMap;
+
+pub async fn register(config: &Config) -> CreateCommand {
+    let cmd_desc = get_translated_message(
+        config,
+        "slash_command.add_staff_command_description",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    let user_id_desc = get_translated_message(
+        config,
+        "slash_command.add_staff_user_id_argument",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    CreateCommand::new("add_staff")
+        .description(cmd_desc)
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
+                .required(true),
+        )
+}
+
+pub async fn run(
+    ctx: &Context,
+    command: &CommandInteraction,
+    _options: &[ResolvedOption<'_>],
+    config: &Config,
+) -> ModmailResult<()> {
+    let pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(common::database_connection_failed)?;
+
+    let user_id = match command
+        .data
+        .options
+        .iter()
+        .find(|opt| opt.name == "user_id")
+    {
+        Some(opt) => match &opt.value {
+            CommandDataOptionValue::User(user_id) => *user_id,
+            _ => {
+                return Err(ModmailError::Command(CommandError::InvalidArguments(
+                    "user_id".to_string(),
+                )));
+            }
+        },
+        None => return Err(ModmailError::Command(CommandError::MissingArguments)),
+    };
+
+    if thread_exists(command.user.id, pool).await {
+        match add_user_to_channel(ctx, command.channel_id, user_id).await {
+            Ok(_) => {
+                let mut params = HashMap::new();
+                params.insert("user".to_string(), format!("<@{}>", user_id));
+
+                let response = MessageBuilder::system_message(ctx, config)
+                    .translated_content("add_staff.add_success", Some(&params), None, None)
+                    .await
+                    .to_channel(command.channel_id)
+                    .build_interaction_message()
+                    .await;
+
+                let _ = command
+                    .create_response(&ctx.http, CreateInteractionResponse::Message(response))
+                    .await;
+
+                Ok(())
+            }
+            Err(..) => Err(ModmailError::Command(InvalidFormat)),
+        }
+    } else {
+        Err(ModmailError::Thread(NotAThreadChannel))
+    }
+}

--- a/src/commands/add_staff/slash_command/mod.rs
+++ b/src/commands/add_staff/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod add_staff;

--- a/src/commands/add_staff/text_command/add_staff.rs
+++ b/src/commands/add_staff/text_command/add_staff.rs
@@ -1,51 +1,13 @@
+use crate::commands::add_staff::common::add_user_to_channel;
+use crate::commands::add_staff::common::extract_user_id;
 use crate::config::Config;
 use crate::db::thread_exists;
 use crate::errors::CommandError::InvalidFormat;
 use crate::errors::ThreadError::NotAThreadChannel;
 use crate::errors::{ModmailError, ModmailResult, common};
 use crate::utils::message::message_builder::MessageBuilder;
-use serenity::all::{
-    ChannelId, Context, Message, PermissionOverwrite, PermissionOverwriteType, UserId,
-};
-use serenity::model::Permissions;
+use serenity::all::{Context, Message, UserId};
 use std::collections::HashMap;
-
-async fn add_user_to_channel(
-    ctx: &Context,
-    channel_id: ChannelId,
-    user_id: UserId,
-) -> ModmailResult<()> {
-    let allow = Permissions::VIEW_CHANNEL | Permissions::SEND_MESSAGES;
-
-    channel_id
-        .create_permission(
-            &ctx.http,
-            PermissionOverwrite {
-                allow,
-                deny: Permissions::empty(),
-                kind: PermissionOverwriteType::Member(user_id),
-            },
-        )
-        .await?;
-
-    Ok(())
-}
-
-async fn extract_user_id(msg: &Message, config: &Config) -> String {
-    let content = msg.content.trim();
-    let prefix = &config.command.prefix;
-    let command_names = ["add_staff", "as"];
-
-    if command_names
-        .iter()
-        .any(|&name| content.starts_with(&format!("{}{}", prefix, name)))
-    {
-        let start = prefix.len() + command_names[0].len();
-        content[start..].trim().to_string()
-    } else {
-        String::new()
-    }
-}
 
 pub async fn add_staff(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
     let pool = config

--- a/src/commands/add_staff/text_command/mod.rs
+++ b/src/commands/add_staff/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod add_staff;

--- a/src/commands/edit/slash_command/edit.rs
+++ b/src/commands/edit/slash_command/edit.rs
@@ -1,11 +1,9 @@
-use crate::commands::edit::message_ops::{
-    edit_messages, format_new_message, get_message_ids,
-};
+use crate::commands::edit::message_ops::{edit_messages, format_new_message, get_message_ids};
 use crate::commands::edit::validation::validate_edit_permissions;
 use crate::config::Config;
 use crate::db::{get_thread_message_by_inbox_message_id, update_message_content};
 use crate::errors::common::message_not_found;
-use crate::errors::{common, ModmailResult};
+use crate::errors::{ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::conversion::hex_string_to_int::hex_string_to_int;
 use crate::utils::message::message_builder::MessageBuilder;

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -1,3 +1,4 @@
+use crate::commands::add_staff::slash_command::add_staff;
 use crate::commands::close::slash_command::close;
 use crate::commands::edit::slash_command::edit;
 use crate::commands::id::slash_command::id;
@@ -63,6 +64,9 @@ impl EventHandler for InteractionHandler {
                     }
                     "edit" => {
                         edit::run(&ctx, &command, &command.data.options(), &self.config).await
+                    }
+                    "add_staff" => {
+                        add_staff::run(&ctx, &command, &command.data.options(), &self.config).await
                     }
                     _ => Err(ModmailError::Command(CommandError::UnknownSlashCommand(
                         command.data.name.clone(),

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -1,4 +1,4 @@
-use crate::commands::add_staff::add_staff;
+use crate::commands::add_staff::text_command::add_staff::add_staff;
 use crate::commands::close::text_command::close::close;
 use crate::commands::edit::message_ops::edit_inbox_message;
 use crate::commands::edit::text_command::edit::edit;
@@ -8,11 +8,7 @@ use crate::commands::move_thread::text_command::move_thread::move_thread;
 use crate::commands::new_thread::text_command::new_thread::new_thread;
 use crate::commands::remove_staff::remove_staff;
 use crate::commands::{
-    alert::alert,
-    anonreply::anonreply,
-    delete::delete,
-    recover::recover,
-    reply::reply,
+    alert::alert, anonreply::anonreply, delete::delete, recover::recover, reply::reply,
 };
 use crate::config::Config;
 use crate::db::messages::get_thread_message_by_dm_message_id;

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -1,3 +1,4 @@
+use crate::commands::add_staff::slash_command::add_staff;
 use crate::commands::close::slash_command::close;
 use crate::commands::edit::slash_command::edit;
 use crate::commands::id::slash_command::id;
@@ -54,6 +55,7 @@ impl EventHandler for ReadyHandler {
                     new_thread::register(&self.config).await,
                     close::register(&self.config).await,
                     edit::register(&self.config).await,
+                    add_staff::register(&self.config).await,
                 ],
             )
             .await;

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -653,4 +653,14 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         "slash_command.edit_message_argument".to_string(),
         DictionaryMessage::new("The new content for the message."),
     );
+    dict.messages.insert(
+        "slash_command.add_staff_command_description".to_string(),
+        DictionaryMessage::new(
+            "Add a staff member to the current ticket to which he does not have access",
+        ),
+    );
+    dict.messages.insert(
+        "slash_command.add_staff_user_id_argument".to_string(),
+        DictionaryMessage::new("The ID of the staff to add to the ticket"),
+    );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -668,4 +668,14 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "slash_command.edit_message_argument".to_string(),
         DictionaryMessage::new("Le nouveau contenu du message"),
     );
+    dict.messages.insert(
+        "slash_command.add_staff_command_description".to_string(),
+        DictionaryMessage::new(
+            "Ajouter un membre du staff à un ticket de support auquel il n'a pas accès",
+        ),
+    );
+    dict.messages.insert(
+        "slash_command.add_staff_user_id_argument".to_string(),
+        DictionaryMessage::new("L'ID du staff à ajouter au ticket"),
+    );
 }


### PR DESCRIPTION
This pull request introduces a new "add_staff" command, allowing staff members to be added to a ticket both via text and slash commands. The implementation is modularized, with shared logic extracted for reuse, and includes internationalization support for both English and French. Integration with the command handler and registration systems ensures the new command is fully functional in the bot.

**New "add_staff" command implementation:**

- Added a new modular structure for the `add_staff` command, splitting it into `text_command` and `slash_command` submodules, and extracting shared logic (such as permission management and user ID extraction) into a `common` module. (`[[1]](diffhunk://#diff-586d12ebb27ada0793333a5b81fe36345fa230429dfcad8f9174b172528453adR1-R43)`, `[[2]](diffhunk://#diff-48984e8fd2e7df03440387d53d5bab9f52ec8651009a593181c969c2919a53c5R1-R3)`, `[[3]](diffhunk://#diff-11bd5f2a18846f20bdec82964c1b4cb8e630604979751e1c4eeb6684577b7927R1)`, `[[4]](diffhunk://#diff-e50903de6995ac0f1ff4eec3d0c940f3a9377aae7aa7f4cb5a685db7d61cd27eR1-L49)`)
- Implemented the slash command version of `add_staff`, including registration, argument parsing, permission changes, and response messaging. (`[src/commands/add_staff/slash_command/add_staff.rsR1-R96](diffhunk://#diff-9e6162286542587fcbe142a0702ef0c49368bbf691bb73f4b2a63fcbc05b10bdR1-R96)`)
- Refactored the text command version of `add_staff` to use the new shared logic from the `common` module. (`[src/commands/add_staff/text_command/add_staff.rsR1-L49](diffhunk://#diff-e50903de6995ac0f1ff4eec3d0c940f3a9377aae7aa7f4cb5a685db7d61cd27eR1-L49)`)

**Integration with bot handlers:**

- Integrated the new `add_staff` command into the event handlers for both slash and text commands, ensuring it is registered and invoked correctly. (`[[1]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R1)`, `[[2]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R68-R70)`, `[[3]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098L1-R1)`, `[[4]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098L11-R11)`, `[[5]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R1)`, `[[6]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R58)`)

**Internationalization:**

- Added English and French translations for the new slash command's description and argument. (`[[1]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R656-R665)`, `[[2]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R671-R680)`)