### PR TITLE
feat(commands): add complete slash command for remove_staff command

### DIFF
--- a/src/commands/remove_staff/common.rs
+++ b/src/commands/remove_staff/common.rs
@@ -1,0 +1,42 @@
+use crate::config::Config;
+use crate::errors::ModmailResult;
+use serenity::all::{
+    ChannelId, Context, Message, PermissionOverwrite, PermissionOverwriteType, Permissions, UserId,
+};
+
+pub async fn remove_user_from_channel(
+    ctx: &Context,
+    channel_id: ChannelId,
+    user_id: UserId,
+) -> ModmailResult<()> {
+    let deny = Permissions::VIEW_CHANNEL | Permissions::SEND_MESSAGES;
+
+    channel_id
+        .create_permission(
+            &ctx.http,
+            PermissionOverwrite {
+                allow: Permissions::empty(),
+                deny,
+                kind: PermissionOverwriteType::Member(user_id),
+            },
+        )
+        .await?;
+
+    Ok(())
+}
+
+pub async fn extract_user_id(msg: &Message, config: &Config) -> String {
+    let content = msg.content.trim();
+    let prefix = &config.command.prefix;
+    let command_names = ["remove_staff", "rs"];
+
+    if command_names
+        .iter()
+        .any(|&name| content.starts_with(&format!("{}{}", prefix, name)))
+    {
+        let start = prefix.len() + command_names[0].len();
+        content[start..].trim().to_string()
+    } else {
+        String::new()
+    }
+}

--- a/src/commands/remove_staff/mod.rs
+++ b/src/commands/remove_staff/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod slash_command;
+pub mod text_command;

--- a/src/commands/remove_staff/slash_command/mod.rs
+++ b/src/commands/remove_staff/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod remove_staff;

--- a/src/commands/remove_staff/slash_command/remove_staff.rs
+++ b/src/commands/remove_staff/slash_command/remove_staff.rs
@@ -1,0 +1,96 @@
+use crate::commands::remove_staff::common::remove_user_from_channel;
+use crate::config::Config;
+use crate::db::thread_exists;
+use crate::errors::CommandError::InvalidFormat;
+use crate::errors::ThreadError::NotAThreadChannel;
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::i18n::get_translated_message;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{
+    CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand,
+    CreateCommandOption, CreateInteractionResponse, ResolvedOption,
+};
+use std::collections::HashMap;
+
+pub async fn register(config: &Config) -> CreateCommand {
+    let cmd_desc = get_translated_message(
+        config,
+        "slash_command.remove_staff_command_description",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let user_id_desc = get_translated_message(
+        config,
+        "slash_command.remove_staff_user_id_argument",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    CreateCommand::new("remove_staff")
+        .description(cmd_desc)
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
+                .required(true),
+        )
+}
+
+pub async fn run(
+    ctx: &Context,
+    command: &CommandInteraction,
+    _options: &[ResolvedOption<'_>],
+    config: &Config,
+) -> ModmailResult<()> {
+    let pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(common::database_connection_failed)?;
+
+    let user_id = match command
+        .data
+        .options
+        .iter()
+        .find(|opt| opt.name == "user_id")
+    {
+        Some(opt) => match &opt.value {
+            CommandDataOptionValue::User(user_id) => *user_id,
+            _ => {
+                return Err(ModmailError::Command(CommandError::InvalidArguments(
+                    "user_id".to_string(),
+                )));
+            }
+        },
+        None => return Err(ModmailError::Command(CommandError::MissingArguments)),
+    };
+
+    if thread_exists(command.user.id, pool).await {
+        match remove_user_from_channel(ctx, command.channel_id, user_id).await {
+            Ok(_) => {
+                let mut params = HashMap::new();
+                params.insert("user".to_string(), format!("<@{}>", user_id));
+
+                let response = MessageBuilder::system_message(ctx, config)
+                    .translated_content("add_staff.remove_success", Some(&params), None, None)
+                    .await
+                    .to_channel(command.channel_id)
+                    .build_interaction_message()
+                    .await;
+
+                let _ = command
+                    .create_response(&ctx.http, CreateInteractionResponse::Message(response))
+                    .await;
+
+                Ok(())
+            }
+            Err(..) => Err(ModmailError::Command(InvalidFormat)),
+        }
+    } else {
+        Err(ModmailError::Thread(NotAThreadChannel))
+    }
+}

--- a/src/commands/remove_staff/text_command/mod.rs
+++ b/src/commands/remove_staff/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod remove_staff;

--- a/src/commands/remove_staff/text_command/remove_staff.rs
+++ b/src/commands/remove_staff/text_command/remove_staff.rs
@@ -1,51 +1,12 @@
+use crate::commands::remove_staff::common::{extract_user_id, remove_user_from_channel};
 use crate::config::Config;
 use crate::db::thread_exists;
 use crate::errors::CommandError::InvalidFormat;
 use crate::errors::ThreadError::NotAThreadChannel;
 use crate::errors::{ModmailError, ModmailResult, common};
 use crate::utils::message::message_builder::MessageBuilder;
-use serenity::all::{
-    ChannelId, Context, Message, PermissionOverwrite, PermissionOverwriteType, UserId,
-};
-use serenity::model::Permissions;
+use serenity::all::{Context, Message, UserId};
 use std::collections::HashMap;
-
-async fn remove_user_from_channel(
-    ctx: &Context,
-    channel_id: ChannelId,
-    user_id: UserId,
-) -> ModmailResult<()> {
-    let deny = Permissions::VIEW_CHANNEL | Permissions::SEND_MESSAGES;
-
-    channel_id
-        .create_permission(
-            &ctx.http,
-            PermissionOverwrite {
-                allow: Permissions::empty(),
-                deny,
-                kind: PermissionOverwriteType::Member(user_id),
-            },
-        )
-        .await?;
-
-    Ok(())
-}
-
-async fn extract_user_id(msg: &Message, config: &Config) -> String {
-    let content = msg.content.trim();
-    let prefix = &config.command.prefix;
-    let command_names = ["remove_staff", "rs"];
-
-    if command_names
-        .iter()
-        .any(|&name| content.starts_with(&format!("{}{}", prefix, name)))
-    {
-        let start = prefix.len() + command_names[0].len();
-        content[start..].trim().to_string()
-    } else {
-        String::new()
-    }
-}
 
 pub async fn remove_staff(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
     let pool = config

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -4,6 +4,7 @@ use crate::commands::edit::slash_command::edit;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
 use crate::commands::new_thread::slash_command::new_thread;
+use crate::commands::remove_staff::slash_command::remove_staff;
 use crate::config::Config;
 use crate::errors::{CommandError, ModmailError};
 use crate::features::handle_feature_component_interaction;
@@ -67,6 +68,10 @@ impl EventHandler for InteractionHandler {
                     }
                     "add_staff" => {
                         add_staff::run(&ctx, &command, &command.data.options(), &self.config).await
+                    }
+                    "remove_staff" => {
+                        remove_staff::run(&ctx, &command, &command.data.options(), &self.config)
+                            .await
                     }
                     _ => Err(ModmailError::Command(CommandError::UnknownSlashCommand(
                         command.data.name.clone(),

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -6,7 +6,7 @@ use crate::commands::force_close::force_close;
 use crate::commands::id::text_command::id::id;
 use crate::commands::move_thread::text_command::move_thread::move_thread;
 use crate::commands::new_thread::text_command::new_thread::new_thread;
-use crate::commands::remove_staff::remove_staff;
+use crate::commands::remove_staff::text_command::remove_staff::remove_staff;
 use crate::commands::{
     alert::alert, anonreply::anonreply, delete::delete, recover::recover, reply::reply,
 };

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -4,6 +4,7 @@ use crate::commands::edit::slash_command::edit;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
 use crate::commands::new_thread::slash_command::new_thread;
+use crate::commands::remove_staff::slash_command::remove_staff;
 use crate::config::Config;
 use crate::features::sync_features;
 use crate::modules::message_recovery::{recover_missing_messages, send_recovery_summary};
@@ -56,6 +57,7 @@ impl EventHandler for ReadyHandler {
                     close::register(&self.config).await,
                     edit::register(&self.config).await,
                     add_staff::register(&self.config).await,
+                    remove_staff::register(&self.config).await,
                 ],
             )
             .await;

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -663,4 +663,12 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         "slash_command.add_staff_user_id_argument".to_string(),
         DictionaryMessage::new("The ID of the staff to add to the ticket"),
     );
+    dict.messages.insert(
+        "slash_command.remove_staff_command_description".to_string(),
+        DictionaryMessage::new("Remove a staff member from the current ticket"),
+    );
+    dict.messages.insert(
+        "slash_command.remove_staff_user_id_argument".to_string(),
+        DictionaryMessage::new("The ID of the staff to remove from the ticket"),
+    );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -678,4 +678,12 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "slash_command.add_staff_user_id_argument".to_string(),
         DictionaryMessage::new("L'ID du staff à ajouter au ticket"),
     );
+    dict.messages.insert(
+        "slash_command.remove_staff_command_description".to_string(),
+        DictionaryMessage::new("Retirer un membre du staff d'un ticket de support"),
+    );
+    dict.messages.insert(
+        "slash_command.remove_staff_user_id_argument".to_string(),
+        DictionaryMessage::new("L'ID du staff à retirer du ticket"),
+    );
 }


### PR DESCRIPTION
This pull request introduces a new "remove staff" command, allowing staff members to be removed from a ticket via both text and slash commands. The implementation includes code refactoring to modularize command logic, updates to command registration, and additions to internationalization files for proper user-facing messages.

**New "Remove Staff" Command Implementation:**

* Added a new modularized command under `src/commands/remove_staff/` that supports both text and slash command interfaces for removing a staff member from a ticket. The core logic for permission changes and user ID extraction has been moved to a shared `common` module. [[1]](diffhunk://#diff-5393f39f8760a7bb90023227fef314bead618a9f93dec75404ba4103967b3dc5R1-R42) [[2]](diffhunk://#diff-825910236310d47b5bf3eb9f3a4fdd13c01addc7ff5a0856d7c251a31447a8cbR1-L49) [[3]](diffhunk://#diff-f0c89ae0be573ad8daa1672c1ea08299868bc7f775b62892ab830cbaf70bfb55R1-R96) [[4]](diffhunk://#diff-6e6e6ff5046eee34f54da973b8ee46a8d1310936a9f82d6c199afae8f0753337R1-R3) [[5]](diffhunk://#diff-e202e8d67154fd521093d37c8627e466f41e2b37d1baa41fd4154ffcf8007bbfR1)

**Integration with Handlers and Registration:**

* Registered the new slash command in both the ready and interaction event handlers, enabling the bot to recognize and respond to `/remove_staff` commands. [[1]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R7) [[2]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R72-R75) [[3]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R7) [[4]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R60)
* Updated the message handler to use the new modularized text command implementation.

**Internationalization (i18n) Updates:**

* Added English and French translations for the new command’s description and argument, ensuring proper localization support. [[1]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R666-R673) [[2]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R681-R688)