### PR TITLE
feat(commands): add complete slash command for force_close command

### DIFF
--- a/src/commands/force_close/common.rs
+++ b/src/commands/force_close/common.rs
@@ -1,0 +1,13 @@
+use crate::errors::DiscordError::ApiError;
+use crate::errors::{ModmailError, ModmailResult};
+use serenity::all::{ChannelId, Context};
+
+pub async fn delete_channel(ctx: &Context, channel_id: ChannelId) -> ModmailResult<()> {
+    match channel_id.delete(ctx).await {
+        Ok(_) => {
+            println!("Channel {} deleted successfully", channel_id);
+            Ok(())
+        }
+        Err(e) => Err(ModmailError::Discord(ApiError(e.to_string()))),
+    }
+}

--- a/src/commands/force_close/mod.rs
+++ b/src/commands/force_close/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod slash_command;
+pub mod text_command;

--- a/src/commands/force_close/slash_command/force_close.rs
+++ b/src/commands/force_close/slash_command/force_close.rs
@@ -1,0 +1,70 @@
+use crate::commands::force_close::common::delete_channel;
+use crate::config::Config;
+use crate::db::threads::{is_a_ticket_channel, is_orphaned_thread_channel};
+use crate::errors::DatabaseError::QueryFailed;
+use crate::errors::ThreadError::{NotAThreadChannel, UserStillInServer};
+use crate::errors::{ModmailError, ModmailResult, common};
+use crate::i18n::get_translated_message;
+use serenity::all::{CommandInteraction, Context, CreateCommand, ResolvedOption};
+
+pub async fn register(config: &Config) -> CreateCommand {
+    let cmd_desc = get_translated_message(
+        config,
+        "slash_command.force_close_command_description",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    CreateCommand::new("force_close").description(cmd_desc)
+}
+
+pub async fn run(
+    ctx: &Context,
+    command: &CommandInteraction,
+    _options: &[ResolvedOption<'_>],
+    config: &Config,
+) -> ModmailResult<()> {
+    let db_pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(common::database_connection_failed)?;
+
+    if !is_a_ticket_channel(command.channel_id, db_pool).await {
+        match command.channel_id.to_channel(&ctx.http).await {
+            Ok(channel) => {
+                let guild_channel = match channel.guild() {
+                    Some(guild_channel) => guild_channel,
+                    None => {
+                        return Err(ModmailError::Thread(NotAThreadChannel));
+                    }
+                };
+
+                if let Some(category_id) = guild_channel.parent_id {
+                    if category_id == config.thread.inbox_category_id {
+                        delete_channel(ctx, command.channel_id).await?;
+                    } else {
+                        return Err(ModmailError::Thread(NotAThreadChannel));
+                    }
+                }
+            }
+            Err(_) => {
+                return Err(ModmailError::Thread(NotAThreadChannel));
+            }
+        }
+    }
+
+    match is_orphaned_thread_channel(command.channel_id, db_pool).await {
+        Ok(res) => {
+            if !res {
+                return Err(ModmailError::Thread(UserStillInServer));
+            }
+            delete_channel(ctx, command.channel_id).await
+        }
+        Err(..) => Err(ModmailError::Database(QueryFailed(
+            "Failed to check if thread channel is orphaned".to_string(),
+        ))),
+    }
+}

--- a/src/commands/force_close/slash_command/mod.rs
+++ b/src/commands/force_close/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod force_close;

--- a/src/commands/force_close/text_command/force_close.rs
+++ b/src/commands/force_close/text_command/force_close.rs
@@ -1,20 +1,10 @@
+use crate::commands::force_close::common::delete_channel;
 use crate::config::Config;
-use crate::db::operations::threads::{is_a_ticket_channel, is_orphaned_thread_channel};
+use crate::db::threads::{is_a_ticket_channel, is_orphaned_thread_channel};
 use crate::errors::DatabaseError::QueryFailed;
-use crate::errors::DiscordError::ApiError;
 use crate::errors::ThreadError::{NotAThreadChannel, UserStillInServer};
 use crate::errors::{ModmailError, ModmailResult, common};
-use serenity::all::{ChannelId, Context, Message};
-
-async fn delete_channel(ctx: &Context, channel_id: ChannelId) -> ModmailResult<()> {
-    match channel_id.delete(ctx).await {
-        Ok(_) => {
-            println!("Channel {} deleted successfully", channel_id);
-            Ok(())
-        }
-        Err(e) => Err(ModmailError::Discord(ApiError(e.to_string()))),
-    }
-}
+use serenity::all::{Context, Message};
 
 pub async fn force_close(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
     let db_pool = config

--- a/src/commands/force_close/text_command/mod.rs
+++ b/src/commands/force_close/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod force_close;

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -2,6 +2,7 @@ use crate::commands::add_staff::slash_command::add_staff;
 use crate::commands::alert::slash_command::alert;
 use crate::commands::close::slash_command::close;
 use crate::commands::edit::slash_command::edit;
+use crate::commands::force_close::slash_command::force_close;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
 use crate::commands::new_thread::slash_command::new_thread;
@@ -76,6 +77,10 @@ impl EventHandler for InteractionHandler {
                     }
                     "alert" => {
                         alert::run(&ctx, &command, &command.data.options(), &self.config).await
+                    }
+                    "force_close" => {
+                        force_close::run(&ctx, &command, &command.data.options(), &self.config)
+                            .await
                     }
                     _ => Err(ModmailError::Command(CommandError::UnknownSlashCommand(
                         command.data.name.clone(),

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -3,7 +3,7 @@ use crate::commands::alert::text_command::alert::alert;
 use crate::commands::close::text_command::close::close;
 use crate::commands::edit::message_ops::edit_inbox_message;
 use crate::commands::edit::text_command::edit::edit;
-use crate::commands::force_close::force_close;
+use crate::commands::force_close::text_command::force_close::force_close;
 use crate::commands::id::text_command::id::id;
 use crate::commands::move_thread::text_command::move_thread::move_thread;
 use crate::commands::new_thread::text_command::new_thread::new_thread;

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -2,6 +2,7 @@ use crate::commands::add_staff::slash_command::add_staff;
 use crate::commands::alert::slash_command::alert;
 use crate::commands::close::slash_command::close;
 use crate::commands::edit::slash_command::edit;
+use crate::commands::force_close::slash_command::force_close;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
 use crate::commands::new_thread::slash_command::new_thread;
@@ -60,6 +61,7 @@ impl EventHandler for ReadyHandler {
                     add_staff::register(&self.config).await,
                     remove_staff::register(&self.config).await,
                     alert::register(&self.config).await,
+                    force_close::register(&self.config).await,
                 ],
             )
             .await;

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -681,4 +681,8 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         "slash_command.alert_cancel_argument".to_string(),
         DictionaryMessage::new("Set to true to cancel the alert"),
     );
+    dict.messages.insert(
+        "slash_command.force_close_command_description".to_string(),
+        DictionaryMessage::new("Force close the current thread which the user has left the server"),
+    );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -694,4 +694,8 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "slash_command.alert_cancel_argument".to_string(),
         DictionaryMessage::new("Annuler l'alerte"),
     );
+    dict.messages.insert(
+        "slash_command.force_close_command_description".to_string(),
+        DictionaryMessage::new("Forcer la fermeture d'un ticket de support dont l'utilisateur n'est plus membre du serveur"),
+    );
 }


### PR DESCRIPTION
This pull request refactors and extends the "force close" command for modmail threads, introducing a new slash command implementation alongside the existing text command. It modularizes the code for better maintainability, adds internationalization support for the new command, and ensures both command styles share core logic for deleting channels.

**Command Refactoring and Modularization:**

- Split the original `force_close` command into a modular structure with separate submodules for `common`, `slash_command`, and `text_command`, moving shared logic (like `delete_channel`) into a reusable `common` module. (`src/commands/force_close/common.rs`, `src/commands/force_close/mod.rs`, `src/commands/force_close/slash_command/mod.rs`, `src/commands/force_close/text_command/mod.rs`, [[1]](diffhunk://#diff-000ab043b0ac71f5ef9735332e82388047cec0d5e7c484cf4954c63524d57642R1-R7) [[2]](diffhunk://#diff-8dfb60f0730064dadc912392e0b116988717a6818ef22e439a73333893ec479bR1-R13) [[3]](diffhunk://#diff-23abbb72a4477a911812938eafec46e2278f039220c0173b711c3faf960cc925R1-R3) [[4]](diffhunk://#diff-d0e599efcafc4cd12997a16e093b20df0c3382c9675d4045076f0d6fd1368ac8R1)

**New Slash Command Implementation:**

- Added a new `force_close` slash command, including registration, command description, and execution logic, mirroring the functionality of the text command and using shared validation and deletion logic. (`src/commands/force_close/slash_command/force_close.rs`, [src/commands/force_close/slash_command/force_close.rsR1-R70](diffhunk://#diff-d160b6f80a0eef26ae5e8f53a26d59f353b6b854f8a43376e8c8590235304dcbR1-R70))
- Registered the new slash command in the bot's ready and interaction handlers, enabling its use in Discord. (`src/handlers/ready_handler.rs`, `src/handlers/guild_interaction_handler.rs`, [[1]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R5) [[2]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R64) [[3]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R5) [[4]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R81-R84)

**Internationalization Support:**

- Added English and French translations for the new slash command's description, ensuring the command is accessible to users in both languages. (`src/i18n/language/en.rs`, `src/i18n/language/fr.rs`, [[1]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R684-R687) [[2]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R697-R700)

**Codebase Consistency:**

- Updated imports and handler logic to reflect the new module structure and ensure both text and slash commands are routed correctly. (`src/handlers/guild_messages_handler.rs`, [src/handlers/guild_messages_handler.rsL6-R6](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098L6-R6))

These changes improve maintainability, enable a more modern Discord command interface, and provide a consistent experience across languages.