### PR TITLE
feat(commands): add complete slash command for help command

### DIFF
--- a/src/commands/help/mod.rs
+++ b/src/commands/help/mod.rs
@@ -1,0 +1,2 @@
+pub mod slash_command;
+pub mod text_command;

--- a/src/commands/help/slash_command/mod.rs
+++ b/src/commands/help/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod help;

--- a/src/commands/help/text_command/help.rs
+++ b/src/commands/help/text_command/help.rs
@@ -1,0 +1,29 @@
+use crate::config::Config;
+use crate::errors::ModmailResult;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{Context, Message};
+
+pub async fn help(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
+    let help_message = "# Available commands:\n\n\
+        **!add_staff <staff_id>** - Add a staff to an hidden ticket\n\
+        **!remove_staff <staff_id>** - Remove a staff from a ticket\n\
+        **!alert** - Alert staff in the current thread when a new user answer arrives \n\
+        **!help** - Show this help message\n\
+        **!reply <message>** - Reply to a ticket\n\
+        **!annonreply <message>** - Reply anonymously to a ticket\n\
+        **!close [reason]** - Close the current thread with an optional reason\n\
+        **!delete [reason]** - Delete the current thread with an optional reason\n\
+        **!hide** - Make the current thread hidden to non-staff members\n\
+        **!new_thread <user_id>** - Create a new ticket with a specific user\n\
+        **!alert [cancel]** - Set or cancel an alert for staff in the current thread\n\
+        **!force_close** - Force close the current thread if it's orphaned\n\
+        **!id** - Show the user ID associated with the current thread";
+
+    MessageBuilder::system_message(ctx, config)
+        .content(help_message)
+        .to_channel(msg.channel_id)
+        .send()
+        .await?;
+
+    Ok(())
+}

--- a/src/commands/help/text_command/mod.rs
+++ b/src/commands/help/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod help;

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -4,6 +4,7 @@ use crate::commands::close::slash_command::close;
 use crate::commands::delete::slash_command::delete;
 use crate::commands::edit::slash_command::edit;
 use crate::commands::force_close::slash_command::force_close;
+use crate::commands::help::slash_command::help;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
 use crate::commands::new_thread::slash_command::new_thread;
@@ -93,6 +94,9 @@ impl EventHandler for InteractionHandler {
                     }
                     "recover" => {
                         recover::run(&ctx, &command, &command.data.options(), &self.config).await
+                    }
+                    "help" => {
+                        help::run(&ctx, &command, &command.data.options(), &self.config).await
                     }
                     _ => Err(ModmailError::Command(CommandError::UnknownSlashCommand(
                         command.data.name.clone(),

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -6,6 +6,7 @@ use crate::commands::delete::text_command::delete::delete;
 use crate::commands::edit::message_ops::edit_inbox_message;
 use crate::commands::edit::text_command::edit::edit;
 use crate::commands::force_close::text_command::force_close::force_close;
+use crate::commands::help::text_command::help::help;
 use crate::commands::id::text_command::id::id;
 use crate::commands::move_thread::text_command::move_thread::move_thread;
 use crate::commands::new_thread::text_command::new_thread::new_thread;
@@ -34,7 +35,6 @@ use serenity::{
 use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex};
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
-use crate::commands::help::help;
 
 static SUPPRESSED_DELETES: LazyLock<Mutex<HashSet<u64>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -4,6 +4,7 @@ use crate::commands::close::slash_command::close;
 use crate::commands::delete::slash_command::delete;
 use crate::commands::edit::slash_command::edit;
 use crate::commands::force_close::slash_command::force_close;
+use crate::commands::help::slash_command::help;
 use crate::commands::id::slash_command::id;
 use crate::commands::move_thread::slash_command::move_thread;
 use crate::commands::new_thread::slash_command::new_thread;
@@ -68,6 +69,7 @@ impl EventHandler for ReadyHandler {
                     reply::register(&self.config).await,
                     delete::register(&self.config).await,
                     recover::register(&self.config).await,
+                    help::register(&self.config).await,
                 ],
             )
             .await;

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -715,4 +715,8 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
             "Retrieve messages missed during the bot's downtime (This process is automatic).",
         ),
     );
+    dict.messages.insert(
+        "slash_command.help_command_description".to_string(),
+        DictionaryMessage::new("Show the help message"),
+    );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -726,4 +726,8 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "slash_command.recover_command_description".to_string(),
         DictionaryMessage::new("Récupérer les messages manqués pendant la période d'indisponibilité du bot (Ce processus est automatique)"),
     );
+    dict.messages.insert(
+        "slash_command.help_command_description".to_string(),
+        DictionaryMessage::new("Afficher le message d'aide"),
+    );
 }


### PR DESCRIPTION
This pull request refactors the help command system by splitting it into separate modules for slash commands and text commands, and adds support for a `/help` slash command. It also updates the command registration and handlers to use the new modular structure and ensures that help messages are available in both English and French.

**Help command modularization and new slash command:**

* Split the help command into `slash_command` and `text_command` modules, organizing the codebase for better maintainability. (`src/commands/help/mod.rs`, `src/commands/help/slash_command/mod.rs`, `src/commands/help/text_command/mod.rs`) [[1]](diffhunk://#diff-03b13871474daa2829f4cfe8b7c1ed4ded342b87ecfc00f0ef26094605aff529R1-R2) [[2]](diffhunk://#diff-946b7b3732d6c64912cae61a97e9bb7b43cda74a4f0a6d811a529432c4949cafR1)
* Implemented the `/help` slash command, including registration, handler logic, and internationalized description. (`src/commands/help/slash_command/help.rs`, `src/handlers/guild_interaction_handler.rs`, `src/handlers/ready_handler.rs`, `src/i18n/language/en.rs`, `src/i18n/language/fr.rs`) [[1]](diffhunk://#diff-932306b3c65d1957543d0231dde03a489c114a7b51fb24b60f1d08d5a39c6f57R1-R54) [[2]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R7) [[3]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R98-R100) [[4]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R7) [[5]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09R72) [[6]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R718-R721) [[7]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R729-R732)

**Text command help adjustments:**

* Moved the text command help implementation to its own module and updated imports in the message handler. (`src/commands/help/text_command/help.rs`, `src/handlers/guild_messages_handler.rs`) [[1]](diffhunk://#diff-103d509cac2c448f17bf6f66d8ea1823cc6b118aef7831ba6f5194231c60a394L1-R4) [[2]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098R9) [[3]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098L37)

**Internationalization:**

* Added English and French translations for the slash command help description. (`src/i18n/language/en.rs`, `src/i18n/language/fr.rs`) [[1]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R718-R721) [[2]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R729-R732)