### PR TITLE
fix(command): fixed too lond description for recover command

### DIFF
--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -53,7 +53,7 @@ impl EventHandler for ReadyHandler {
 
         let guild_id = GuildId::new(self.config.bot.get_staff_guild_id());
 
-        let _ = guild_id
+        if let Err(e) = guild_id
             .set_commands(
                 &ctx.http,
                 vec![
@@ -72,6 +72,9 @@ impl EventHandler for ReadyHandler {
                     help::register(&self.config).await,
                 ],
             )
-            .await;
+            .await
+        {
+            eprintln!("set_commands() failed: {:?}", e);
+        }
     }
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -724,7 +724,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "slash_command.recover_command_description".to_string(),
-        DictionaryMessage::new("Récupérer les messages manqués pendant la période d'indisponibilité du bot (Ce processus est automatique)"),
+        DictionaryMessage::new("Récupérer les messages manqués pendant la période d'indisponibilité du bot (automatique)"),
     );
     dict.messages.insert(
         "slash_command.help_command_description".to_string(),


### PR DESCRIPTION
When switching the bot's language to French, the description of the “recover” command exceeded the 100-character limit imposed by Discord.