### PR TITLE
refactor(slash_commands): refactored slash commands register system

### DIFF
--- a/src/commands/add_staff/slash_command/add_staff.rs
+++ b/src/commands/add_staff/slash_command/add_staff.rs
@@ -1,9 +1,10 @@
 use crate::commands::add_staff::common::add_user_to_channel;
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::thread_exists;
 use crate::errors::CommandError::InvalidFormat;
 use crate::errors::ThreadError::NotAThreadChannel;
-use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
@@ -13,84 +14,106 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.add_staff_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let user_id_desc = get_translated_message(
-        config,
-        "slash_command.add_staff_user_id_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct AddStaffCommand;
 
-    CreateCommand::new("add_staff")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
-                .required(true),
-        )
-}
+impl RegistrableCommand for AddStaffCommand {
+    fn name(&self) -> &'static str {
+        "add_staff"
+    }
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    defer_response(&ctx, &command).await?;
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.add_staff_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let user_id = match command
-        .data
-        .options
-        .iter()
-        .find(|opt| opt.name == "user_id")
-    {
-        Some(opt) => match &opt.value {
-            CommandDataOptionValue::User(user_id) => *user_id,
-            _ => {
-                return Err(ModmailError::Command(CommandError::InvalidArguments(
-                    "user_id".to_string(),
-                )));
+            let user_id_desc = get_translated_message(
+                &config,
+                "slash_command.add_staff_user_id_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+            vec![
+                CreateCommand::new("add_staff")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
+                            .required(true),
+                    ),
+            ]
+        })
+    }
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        _options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            let user_id = match command
+                .data
+                .options
+                .iter()
+                .find(|opt| opt.name == "user_id")
+            {
+                Some(opt) => match &opt.value {
+                    CommandDataOptionValue::User(user_id) => *user_id,
+                    _ => {
+                        return Err(ModmailError::Command(CommandError::InvalidArguments(
+                            "user_id".to_string(),
+                        )));
+                    }
+                },
+                None => return Err(ModmailError::Command(CommandError::MissingArguments)),
+            };
+
+            if thread_exists(command.user.id, pool).await {
+                match add_user_to_channel(&ctx, command.channel_id, user_id).await {
+                    Ok(_) => {
+                        let mut params = HashMap::new();
+                        params.insert("user".to_string(), format!("<@{}>", user_id));
+
+                        let response = MessageBuilder::system_message(&ctx, &config)
+                            .translated_content("add_staff.add_success", Some(&params), None, None)
+                            .await
+                            .to_channel(command.channel_id)
+                            .build_interaction_message_followup()
+                            .await;
+
+                        let _ = command.create_followup(&ctx.http, response).await;
+
+                        Ok(())
+                    }
+                    Err(..) => Err(ModmailError::Command(InvalidFormat)),
+                }
+            } else {
+                Err(ModmailError::Thread(NotAThreadChannel))
             }
-        },
-        None => return Err(ModmailError::Command(CommandError::MissingArguments)),
-    };
-
-    if thread_exists(command.user.id, pool).await {
-        match add_user_to_channel(ctx, command.channel_id, user_id).await {
-            Ok(_) => {
-                let mut params = HashMap::new();
-                params.insert("user".to_string(), format!("<@{}>", user_id));
-
-                let response = MessageBuilder::system_message(ctx, config)
-                    .translated_content("add_staff.add_success", Some(&params), None, None)
-                    .await
-                    .to_channel(command.channel_id)
-                    .build_interaction_message_followup()
-                    .await;
-
-                let _ = command.create_followup(&ctx.http, response).await;
-
-                Ok(())
-            }
-            Err(..) => Err(ModmailError::Command(InvalidFormat)),
-        }
-    } else {
-        Err(ModmailError::Thread(NotAThreadChannel))
+        })
     }
 }

--- a/src/commands/alert/common.rs
+++ b/src/commands/alert/common.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::db::{cancel_alert_for_staff, get_user_id_from_channel_id, set_alert_for_staff};
 use crate::errors::DatabaseError::QueryFailed;
 use crate::errors::DiscordError::ApiError;
-use crate::errors::{ModmailError, ModmailResult, common};
+use crate::errors::{common, ModmailError, ModmailResult};
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::colours::branding::GREEN;
 use serenity::all::{CommandInteraction, Context, CreateInteractionResponse, Message};

--- a/src/commands/alert/slash_command/alert.rs
+++ b/src/commands/alert/slash_command/alert.rs
@@ -2,8 +2,9 @@ use crate::commands::alert::common::{
     get_thread_user_id_from_command, handle_cancel_alert_from_command,
     handle_set_alert_from_command,
 };
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use serenity::all::{
@@ -11,64 +12,86 @@ use serenity::all::{
     CreateCommandOption, ResolvedOption,
 };
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.alert_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let cancel_desc = get_translated_message(
-        config,
-        "slash_command.alert_cancel_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct AlertCommand;
 
-    CreateCommand::new("alert")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::Boolean, "cancel", cancel_desc)
-                .required(false),
-        )
-}
+#[async_trait::async_trait]
+impl RegistrableCommand for AlertCommand {
+    fn name(&self) -> &'static str {
+        "alert"
+    }
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    defer_response(&ctx, &command).await?;
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.alert_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let cancel_desc = get_translated_message(
+                &config,
+                "slash_command.alert_cancel_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let user_id = get_thread_user_id_from_command(ctx, command, config, pool).await?;
+            vec![
+                CreateCommand::new("alert")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(CommandOptionType::Boolean, "cancel", cancel_desc)
+                            .required(false),
+                    ),
+            ]
+        })
+    }
 
-    let is_cancel = match command.data.options.iter().find(|opt| opt.name == "cancel") {
-        Some(opt) => match &opt.value {
-            CommandDataOptionValue::Boolean(cancel) => *cancel,
-            _ => {
-                return Err(ModmailError::Command(CommandError::InvalidArguments(
-                    "user_id".to_string(),
-                )));
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            let user_id = get_thread_user_id_from_command(&ctx, &command, &config, pool).await?;
+
+            let is_cancel = match command.data.options.iter().find(|opt| opt.name == "cancel") {
+                Some(opt) => match &opt.value {
+                    CommandDataOptionValue::Boolean(cancel) => *cancel,
+                    _ => {
+                        return Err(ModmailError::Command(CommandError::InvalidArguments(
+                            "user_id".to_string(),
+                        )));
+                    }
+                },
+                None => false,
+            };
+
+            if is_cancel {
+                handle_cancel_alert_from_command(&ctx, &command, &config, user_id, pool).await
+            } else {
+                handle_set_alert_from_command(&ctx, &command, &config, user_id, pool).await
             }
-        },
-        None => false,
-    };
-
-    if is_cancel {
-        handle_cancel_alert_from_command(ctx, command, config, user_id, pool).await
-    } else {
-        handle_set_alert_from_command(ctx, command, config, user_id, pool).await
+        })
     }
 }

--- a/src/commands/close/slash_command/close.rs
+++ b/src/commands/close/slash_command/close.rs
@@ -1,9 +1,10 @@
 use crate::commands::close::common::parse_duration_spec;
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::{
     close_thread, delete_scheduled_closure, get_scheduled_closure, upsert_scheduled_closure,
 };
-use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
@@ -17,283 +18,314 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.close_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct CloseCommand;
 
-    CreateCommand::new("close").description(cmd_desc).add_option(
-        CreateCommandOption::new(
-            CommandOptionType::String, "time_before_close", "Duration before the thread is closed (e.g., 10m, 1h, 2d). Defaults the thread is closed immediately.")
-            .required(false)
-    ).add_option(
-        CreateCommandOption::new(
-            CommandOptionType::Boolean, "silent", "If set, the user will not be notified when the thread is closed.")
-            .required(false)
-    ).add_option(
-        CreateCommandOption::new(
-            CommandOptionType::Boolean, "cancel", "If set, cancels any scheduled closure for this thread.")
-            .required(false)
-    )
-}
-
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let db_pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
-
-    defer_response(&ctx, &command).await?;
-
-    let mut time_before_close: Option<String> = None;
-    let mut silent: Option<bool> = None;
-    let mut cancel: Option<bool> = None;
-    let mut duration: Option<Duration> = None;
-
-    for option in &command.data.options {
-        match option.name.as_str() {
-            "time_before_close" => {
-                if let CommandDataOptionValue::String(val) = &option.value {
-                    time_before_close.replace(val.clone());
-                }
-            }
-            "silent" => {
-                if let CommandDataOptionValue::Boolean(val) = &option.value {
-                    silent.replace(*val);
-                }
-            }
-            "cancel" => {
-                if let CommandDataOptionValue::Boolean(val) = &option.value {
-                    cancel.replace(*val);
-                }
-            }
-            _ => {}
-        }
+#[async_trait::async_trait]
+impl RegistrableCommand for CloseCommand {
+    fn name(&self) -> &'static str {
+        "close"
     }
 
-    if let Some(time_before_close) = time_before_close {
-        if let Some(dur) = parse_duration_spec(&time_before_close) {
-            duration = Some(dur);
-        }
-    }
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    let thread = fetch_thread(db_pool, &command.channel_id.to_string()).await?;
-    let user_id = UserId::new(thread.user_id as u64);
-    let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.close_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    if let Some(cancel) = cancel
-        && cancel
-    {
-        let existed = delete_scheduled_closure(&thread.id, db_pool)
-            .await
-            .unwrap_or(false);
-        return if existed {
-            let response = MessageBuilder::system_message(ctx, config)
-                .translated_content(
-                    "close.closure_canceled",
-                    None,
-                    Some(command.user.id),
-                    command.guild_id.map(|g| g.get()),
+            vec![
+                CreateCommand::new("close").description(cmd_desc).add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String, "time_before_close", "Duration before the thread is closed (e.g., 10m, 1h, 2d). Defaults the thread is closed immediately.")
+                        .required(false)
+                ).add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::Boolean, "silent", "If set, the user will not be notified when the thread is closed.")
+                        .required(false)
+                ).add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::Boolean, "cancel", "If set, cancels any scheduled closure for this thread.")
+                        .required(false)
                 )
-                .await
-                .to_channel(command.channel_id)
-                .build_interaction_message_followup()
-                .await;
-
-            let _ = command.create_followup(&ctx.http, response).await;
-            Ok(())
-        } else {
-            Err(ModmailError::Command(
-                CommandError::NoSchedulableClosureToCancel,
-            ))
-        };
+            ]
+        })
     }
 
-    if duration.is_none() {
-        if let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await {
-            let remaining = existing.close_at - Utc::now().timestamp();
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
 
-            let mut params = HashMap::new();
-            params.insert("seconds".to_string(), remaining.to_string());
+        Box::pin(async move {
+            let db_pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
 
-            if remaining > 0 {
-                return Err(ModmailError::Command(CommandError::ClosureAlreadyScheduled));
-            }
-        }
-    }
+            defer_response(&ctx, &command).await?;
 
-    if let Some(delay) = duration {
-        let delay_secs = delay.as_secs();
-        let human = if delay_secs < 60 {
-            format!("{}s", delay_secs)
-        } else if delay_secs < 3600 {
-            format!("{}m", delay_secs / 60)
-        } else if delay_secs < 86400 {
-            format!("{}h{}m", delay_secs / 3600, (delay_secs % 3600) / 60)
-        } else {
-            format!("{}d{}h", delay_secs / 86400, (delay_secs % 86400) / 3600)
-        };
-        let mut params = HashMap::new();
-        params.insert("time".to_string(), human);
+            let mut time_before_close: Option<String> = None;
+            let mut silent: Option<bool> = None;
+            let mut cancel: Option<bool> = None;
+            let mut duration: Option<Duration> = None;
 
-        let _ = if let Some(silent) = silent
-            && silent
-        {
-            let response = MessageBuilder::system_message(ctx, config)
-                .translated_content(
-                    "close.silent_closing",
-                    Some(&params),
-                    Some(command.user.id),
-                    command.guild_id.map(|g| g.get()),
-                )
-                .await
-                .to_channel(command.channel_id)
-                .build_interaction_message_followup()
-                .await;
-
-            let _ = command.create_followup(&ctx.http, response).await;
-        } else {
-            let response = MessageBuilder::system_message(ctx, config)
-                .translated_content(
-                    "close.closing",
-                    Some(&params),
-                    Some(command.user.id),
-                    command.guild_id.map(|g| g.get()),
-                )
-                .await
-                .to_channel(command.channel_id)
-                .build_interaction_message_followup()
-                .await;
-
-            let _ = command.create_followup(&ctx.http, response).await;
-        };
-
-        let thread_id = thread.id.clone();
-        let close_at = Utc::now().timestamp() + delay.as_secs() as i64;
-        let silent = silent.unwrap_or(false);
-        if let Err(e) = upsert_scheduled_closure(&thread_id, close_at, silent, db_pool).await {
-            eprintln!("Failed to persist scheduled closure: {e:?}");
-        }
-        let channel_id = command.channel_id;
-        let config_clone = config.clone();
-        let ctx_clone = ctx.clone();
-        let user_id_clone = user_id;
-        let thread_id_for_task = thread_id.clone();
-
-        tokio::spawn(async move {
-            sleep(delay).await;
-            if let Some(pool) = config_clone.db_pool.as_ref() {
-                if let Ok(Some(record)) = get_scheduled_closure(&thread_id_for_task, pool).await {
-                    if record.close_at <= Utc::now().timestamp() {
-                        let _ = close_thread(&thread_id_for_task, pool).await;
-                        let _ = delete_scheduled_closure(&thread_id_for_task, pool).await;
-
-                        let community_guild_id =
-                            GuildId::new(config_clone.bot.get_community_guild_id());
-
-                        let user_still_member = community_guild_id
-                            .member(&ctx_clone.http, user_id_clone)
-                            .await
-                            .is_ok();
-
-                        if !record.silent && user_still_member {
-                            let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
-                                .content(&config_clone.bot.close_message)
-                                .to_user(user_id_clone)
-                                .send()
-                                .await;
+            for option in &command.data.options {
+                match option.name.as_str() {
+                    "time_before_close" => {
+                        if let CommandDataOptionValue::String(val) = &option.value {
+                            time_before_close.replace(val.clone());
                         }
-                        let _ = channel_id.delete(&ctx_clone.http).await;
-                    } else {
-                        let delay2 = (record.close_at - Utc::now().timestamp()).max(1) as u64;
-                        let config_clone2 = config_clone.clone();
-                        let ctx_clone2 = ctx_clone.clone();
-                        let thread_id_again = thread_id_for_task.clone();
+                    }
+                    "silent" => {
+                        if let CommandDataOptionValue::Boolean(val) = &option.value {
+                            silent.replace(*val);
+                        }
+                    }
+                    "cancel" => {
+                        if let CommandDataOptionValue::Boolean(val) = &option.value {
+                            cancel.replace(*val);
+                        }
+                    }
+                    _ => {}
+                }
+            }
 
-                        tokio::spawn(async move {
-                            sleep(Duration::from_secs(delay2)).await;
-                            if let Some(pool2) = config_clone2.db_pool.as_ref() {
-                                if let Ok(Some(r2)) =
-                                    get_scheduled_closure(&thread_id_again, pool2).await
-                                {
-                                    if r2.close_at <= Utc::now().timestamp() {
-                                        let _ = close_thread(&thread_id_again, pool2).await;
-                                        let _ =
-                                            delete_scheduled_closure(&thread_id_again, pool2).await;
-                                        let community_guild_id = GuildId::new(
-                                            config_clone2.bot.get_community_guild_id(),
-                                        );
-                                        let user_still_member = community_guild_id
-                                            .member(&ctx_clone2.http, user_id_clone)
-                                            .await
-                                            .is_ok();
-                                        if !r2.silent && user_still_member {
-                                            let _ = MessageBuilder::system_message(
-                                                &ctx_clone2,
-                                                &config_clone2,
-                                            )
-                                            .content(&config_clone2.bot.close_message)
-                                            .to_user(user_id_clone)
-                                            .send()
-                                            .await;
-                                        }
-                                        let _ = channel_id.delete(&ctx_clone2.http).await;
-                                    }
-                                }
-                            }
-                        });
+            if let Some(time_before_close) = time_before_close {
+                if let Some(dur) = parse_duration_spec(&time_before_close) {
+                    duration = Some(dur);
+                }
+            }
+
+            let thread = fetch_thread(db_pool, &command.channel_id.to_string()).await?;
+            let user_id = UserId::new(thread.user_id as u64);
+            let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
+
+            if let Some(cancel) = cancel
+                && cancel
+            {
+                let existed = delete_scheduled_closure(&thread.id, db_pool)
+                    .await
+                    .unwrap_or(false);
+                return if existed {
+                    let response = MessageBuilder::system_message(&ctx, &config)
+                        .translated_content(
+                            "close.closure_canceled",
+                            None,
+                            Some(command.user.id),
+                            command.guild_id.map(|g| g.get()),
+                        )
+                        .await
+                        .to_channel(command.channel_id)
+                        .build_interaction_message_followup()
+                        .await;
+
+                    let _ = command.create_followup(&ctx.http, response).await;
+                    Ok(())
+                } else {
+                    Err(ModmailError::Command(
+                        CommandError::NoSchedulableClosureToCancel,
+                    ))
+                };
+            }
+
+            if duration.is_none() {
+                if let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await {
+                    let remaining = existing.close_at - Utc::now().timestamp();
+
+                    let mut params = HashMap::new();
+                    params.insert("seconds".to_string(), remaining.to_string());
+
+                    if remaining > 0 {
+                        return Err(ModmailError::Command(CommandError::ClosureAlreadyScheduled));
                     }
                 }
             }
-        });
-        return Ok(());
+
+            if let Some(delay) = duration {
+                let delay_secs = delay.as_secs();
+                let human = if delay_secs < 60 {
+                    format!("{}s", delay_secs)
+                } else if delay_secs < 3600 {
+                    format!("{}m", delay_secs / 60)
+                } else if delay_secs < 86400 {
+                    format!("{}h{}m", delay_secs / 3600, (delay_secs % 3600) / 60)
+                } else {
+                    format!("{}d{}h", delay_secs / 86400, (delay_secs % 86400) / 3600)
+                };
+                let mut params = HashMap::new();
+                params.insert("time".to_string(), human);
+
+                let _ = if let Some(silent) = silent
+                    && silent
+                {
+                    let response = MessageBuilder::system_message(&ctx, &config)
+                        .translated_content(
+                            "close.silent_closing",
+                            Some(&params),
+                            Some(command.user.id),
+                            command.guild_id.map(|g| g.get()),
+                        )
+                        .await
+                        .to_channel(command.channel_id)
+                        .build_interaction_message_followup()
+                        .await;
+
+                    let _ = command.create_followup(&ctx.http, response).await;
+                } else {
+                    let response = MessageBuilder::system_message(&ctx, &config)
+                        .translated_content(
+                            "close.closing",
+                            Some(&params),
+                            Some(command.user.id),
+                            command.guild_id.map(|g| g.get()),
+                        )
+                        .await
+                        .to_channel(command.channel_id)
+                        .build_interaction_message_followup()
+                        .await;
+
+                    let _ = command.create_followup(&ctx.http, response).await;
+                };
+
+                let thread_id = thread.id.clone();
+                let close_at = Utc::now().timestamp() + delay.as_secs() as i64;
+                let silent = silent.unwrap_or(false);
+                if let Err(e) =
+                    upsert_scheduled_closure(&thread_id, close_at, silent, db_pool).await
+                {
+                    eprintln!("Failed to persist scheduled closure: {e:?}");
+                }
+                let channel_id = command.channel_id;
+                let config_clone = config.clone();
+                let ctx_clone = ctx.clone();
+                let user_id_clone = user_id;
+                let thread_id_for_task = thread_id.clone();
+
+                tokio::spawn(async move {
+                    sleep(delay).await;
+                    if let Some(pool) = config_clone.db_pool.as_ref() {
+                        if let Ok(Some(record)) =
+                            get_scheduled_closure(&thread_id_for_task, pool).await
+                        {
+                            if record.close_at <= Utc::now().timestamp() {
+                                let _ = close_thread(&thread_id_for_task, pool).await;
+                                let _ = delete_scheduled_closure(&thread_id_for_task, pool).await;
+
+                                let community_guild_id =
+                                    GuildId::new(config_clone.bot.get_community_guild_id());
+
+                                let user_still_member = community_guild_id
+                                    .member(&ctx_clone.http, user_id_clone)
+                                    .await
+                                    .is_ok();
+
+                                if !record.silent && user_still_member {
+                                    let _ =
+                                        MessageBuilder::system_message(&ctx_clone, &config_clone)
+                                            .content(&config_clone.bot.close_message)
+                                            .to_user(user_id_clone)
+                                            .send()
+                                            .await;
+                                }
+                                let _ = channel_id.delete(&ctx_clone.http).await;
+                            } else {
+                                let delay2 =
+                                    (record.close_at - Utc::now().timestamp()).max(1) as u64;
+                                let config_clone2 = config_clone.clone();
+                                let ctx_clone2 = ctx_clone.clone();
+                                let thread_id_again = thread_id_for_task.clone();
+
+                                tokio::spawn(async move {
+                                    sleep(Duration::from_secs(delay2)).await;
+                                    if let Some(pool2) = config_clone2.db_pool.as_ref() {
+                                        if let Ok(Some(r2)) =
+                                            get_scheduled_closure(&thread_id_again, pool2).await
+                                        {
+                                            if r2.close_at <= Utc::now().timestamp() {
+                                                let _ = close_thread(&thread_id_again, pool2).await;
+                                                let _ = delete_scheduled_closure(
+                                                    &thread_id_again,
+                                                    pool2,
+                                                )
+                                                .await;
+                                                let community_guild_id = GuildId::new(
+                                                    config_clone2.bot.get_community_guild_id(),
+                                                );
+                                                let user_still_member = community_guild_id
+                                                    .member(&ctx_clone2.http, user_id_clone)
+                                                    .await
+                                                    .is_ok();
+                                                if !r2.silent && user_still_member {
+                                                    let _ = MessageBuilder::system_message(
+                                                        &ctx_clone2,
+                                                        &config_clone2,
+                                                    )
+                                                    .content(&config_clone2.bot.close_message)
+                                                    .to_user(user_id_clone)
+                                                    .send()
+                                                    .await;
+                                                }
+                                                let _ = channel_id.delete(&ctx_clone2.http).await;
+                                            }
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                    }
+                });
+                return Ok(());
+            }
+
+            let user_still_member = community_guild_id.member(&ctx.http, user_id).await.is_ok();
+
+            if user_still_member
+                && let Some(silent) = silent
+                && !silent
+            {
+                let _ = MessageBuilder::system_message(&ctx, &config)
+                    .content(&config.bot.close_message)
+                    .to_user(user_id)
+                    .send()
+                    .await;
+            } else if !user_still_member {
+                let mut params = HashMap::new();
+                params.insert("username".to_string(), thread.user_name.clone());
+
+                let response = MessageBuilder::system_message(&ctx, &config)
+                    .translated_content(
+                        "user.left_server_close",
+                        Some(&params),
+                        Some(command.user.id),
+                        command.guild_id.map(|g| g.get()),
+                    )
+                    .await
+                    .to_channel(command.channel_id)
+                    .build_interaction_message_followup()
+                    .await;
+
+                let _ = command.create_followup(&ctx.http, response).await;
+            }
+
+            close_thread(&thread.id, db_pool).await?;
+            let _ = delete_scheduled_closure(&thread.id, db_pool).await;
+
+            let _ = command.channel_id.delete(&ctx.http).await?;
+
+            Ok(())
+        })
     }
-
-    let user_still_member = community_guild_id.member(&ctx.http, user_id).await.is_ok();
-
-    if user_still_member
-        && let Some(silent) = silent
-        && !silent
-    {
-        let _ = MessageBuilder::system_message(ctx, config)
-            .content(&config.bot.close_message)
-            .to_user(user_id)
-            .send()
-            .await;
-    } else if !user_still_member {
-        let mut params = HashMap::new();
-        params.insert("username".to_string(), thread.user_name.clone());
-
-        let response = MessageBuilder::system_message(ctx, config)
-            .translated_content(
-                "user.left_server_close",
-                Some(&params),
-                Some(command.user.id),
-                command.guild_id.map(|g| g.get()),
-            )
-            .await
-            .to_channel(command.channel_id)
-            .build_interaction_message_followup()
-            .await;
-
-        let _ = command.create_followup(&ctx.http, response).await;
-    }
-
-    close_thread(&thread.id, db_pool).await?;
-    let _ = delete_scheduled_closure(&thread.id, db_pool).await;
-
-    let _ = command.channel_id.delete(&ctx.http).await?;
-
-    Ok(())
 }

--- a/src/commands/delete/slash_command/delete.rs
+++ b/src/commands/delete/slash_command/delete.rs
@@ -2,8 +2,9 @@ use crate::commands::delete::common::{
     delete_database_message, delete_discord_messages, get_message_ids, get_thread_info,
     update_message_numbers,
 };
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::errors::{MessageError, ModmailError, ModmailResult, common};
+use crate::errors::{common, MessageError, ModmailError, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response_ephemeral;
 use crate::utils::message::message_builder::MessageBuilder;
@@ -13,86 +14,112 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.delete_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let message_id_desc = get_translated_message(
-        config,
-        "slash_command.delete_message_id_argument_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct DeleteCommand;
 
-    CreateCommand::new("delete")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::Number, "message_id", message_id_desc)
-                .required(true),
-        )
-}
+#[async_trait::async_trait]
+impl RegistrableCommand for DeleteCommand {
+    fn name(&self) -> &'static str {
+        "delete"
+    }
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    defer_response_ephemeral(&ctx, &command).await?;
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.delete_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let message_id_desc = get_translated_message(
+                &config,
+                "slash_command.delete_message_id_argument_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let mut message_number: i64 = -1;
+            vec![
+                CreateCommand::new("delete")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::Number,
+                            "message_id",
+                            message_id_desc,
+                        )
+                        .required(true),
+                    ),
+            ]
+        })
+    }
 
-    for option in &command.data.options {
-        match option.name.as_str() {
-            "message_id" => {
-                if let CommandDataOptionValue::Number(val) = &option.value {
-                    message_number = *val as i64;
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response_ephemeral(&ctx, &command).await?;
+
+            let mut message_number: i64 = -1;
+
+            for option in &command.data.options {
+                match option.name.as_str() {
+                    "message_id" => {
+                        if let CommandDataOptionValue::Number(val) = &option.value {
+                            message_number = *val as i64;
+                        }
+                    }
+                    _ => {}
                 }
             }
-            _ => {}
-        }
+
+            let (user_id, thread) = get_thread_info(&command.channel_id.to_string(), pool).await?;
+
+            if message_number < 0 {
+                return Err(ModmailError::Message(MessageError::MessageNotFound(
+                    "".to_string(),
+                )));
+            }
+
+            let message_ids = get_message_ids(user_id, &thread, message_number, pool).await?;
+
+            delete_discord_messages(&ctx, &command.channel_id, user_id, &message_ids).await?;
+            delete_database_message(&message_ids, pool).await?;
+            update_message_numbers(&thread.channel_id, message_number, pool).await;
+
+            let mut params = HashMap::new();
+            params.insert("number".to_string(), message_number.to_string());
+
+            let response = MessageBuilder::system_message(&ctx, &config)
+                .translated_content("delete.success", Some(&params), None, None)
+                .await
+                .to_channel(command.channel_id)
+                .ephemeral(true)
+                .build_interaction_message_followup()
+                .await;
+
+            let _ = command.create_followup(&ctx.http, response).await;
+
+            Ok(())
+        })
     }
-
-    let (user_id, thread) = get_thread_info(&command.channel_id.to_string(), pool).await?;
-
-    if message_number < 0 {
-        return Err(ModmailError::Message(MessageError::MessageNotFound(
-            "".to_string(),
-        )));
-    }
-
-    let message_ids = get_message_ids(user_id, &thread, message_number, pool).await?;
-
-    delete_discord_messages(ctx, &command.channel_id, user_id, &message_ids).await?;
-    delete_database_message(&message_ids, pool).await?;
-    update_message_numbers(&thread.channel_id, message_number, pool).await;
-
-    let mut params = HashMap::new();
-    params.insert("number".to_string(), message_number.to_string());
-
-    let response = MessageBuilder::system_message(&ctx, &config)
-        .translated_content("delete.success", Some(&params), None, None)
-        .await
-        .to_channel(command.channel_id)
-        .ephemeral(true)
-        .build_interaction_message_followup()
-        .await;
-
-    let _ = command.create_followup(&ctx.http, response).await;
-
-    Ok(())
 }

--- a/src/commands/edit/slash_command/edit.rs
+++ b/src/commands/edit/slash_command/edit.rs
@@ -1,9 +1,10 @@
 use crate::commands::edit::message_ops::{edit_messages, format_new_message, get_message_ids};
 use crate::commands::edit::validation::validate_edit_permissions;
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::{get_thread_message_by_inbox_message_id, update_message_content};
 use crate::errors::common::message_not_found;
-use crate::errors::{ModmailResult, common};
+use crate::errors::{common, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::conversion::hex_string_to_int::hex_string_to_int;
@@ -14,192 +15,225 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.edit_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let msg_id_desc = get_translated_message(
-        config,
-        "slash_command.edit_message_id_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let edit_content_desc = get_translated_message(
-        config,
-        "slash_command.edit_message_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct EditCommand;
 
-    CreateCommand::new("edit")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::Integer, "message_id", msg_id_desc)
-                .required(true),
-        )
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::String, "message", edit_content_desc)
-                .required(true),
-        )
-}
-
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
-
-    defer_response(&ctx, &command).await?;
-
-    let mut msg_id: i64 = 0;
-    let mut new_content: String = String::new();
-
-    for option in command.data.options.iter() {
-        match option.name.as_str() {
-            "message_id" => {
-                if let CommandDataOptionValue::Integer(value) = &option.value {
-                    msg_id = *value;
-                }
-            }
-            "message" => {
-                if let CommandDataOptionValue::String(value) = &option.value {
-                    new_content = value.clone();
-                }
-            }
-            _ => {}
-        }
+#[async_trait::async_trait]
+impl RegistrableCommand for EditCommand {
+    fn name(&self) -> &'static str {
+        "edit"
     }
 
-    match validate_edit_permissions(msg_id, command.channel_id, command.user.id, pool).await {
-        Ok(()) => (),
-        Err(e) => return Err(e),
-    };
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    let ids = match get_message_ids(msg_id, command.user.id, pool, ctx, command.channel_id).await {
-        Ok(ids) => ids,
-        Err(e) => return Err(e),
-    };
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.edit_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let msg_id_desc = get_translated_message(
+                &config,
+                "slash_command.edit_message_id_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let edit_content_desc = get_translated_message(
+                &config,
+                "slash_command.edit_message_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let dm_msg_id = match ids.dm_message_id {
-        Some(msg_id) => msg_id,
-        None => return Err(message_not_found("Inbox message ID not found")),
-    };
-
-    let inbox_message_id = match ids.inbox_message_id {
-        Some(msg_id) => msg_id,
-        None => return Err(message_not_found("DM message ID not found")),
-    };
-
-    let edited_messages_builder = match format_new_message(
-        ctx,
-        (None, Some(command)),
-        &new_content,
-        &inbox_message_id,
-        msg_id as u64,
-        config,
-        pool,
-    )
-    .await
-    {
-        Ok(edited_messages) => edited_messages,
-        Err(e) => return Err(e),
-    };
-
-    let before_content: String =
-        match get_thread_message_by_inbox_message_id(&inbox_message_id, pool).await {
-            Ok(tm) => tm.content,
-            Err(_) => String::new(),
-        };
-
-    let edit_result = edit_messages(
-        ctx,
-        command.channel_id,
-        dm_msg_id.clone(),
-        inbox_message_id.clone(),
-        edited_messages_builder,
-        pool,
-        config,
-    )
-    .await;
-
-    match edit_result {
-        Ok(()) => {
-            if config.notifications.show_success_on_edit {
-                let response = MessageBuilder::system_message(ctx, config)
-                    .translated_content(
-                        "success.message_edited",
-                        None,
-                        Some(command.user.id),
-                        command.guild_id.map(|g| g.get()),
+            vec![
+                CreateCommand::new("edit")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::Integer,
+                            "message_id",
+                            msg_id_desc,
+                        )
+                        .required(true),
                     )
-                    .await
-                    .color(hex_string_to_int(&config.thread.system_message_color) as u32)
-                    .to_channel(command.channel_id)
-                    .build_interaction_message_followup()
-                    .await;
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "message",
+                            edit_content_desc,
+                        )
+                        .required(true),
+                    ),
+            ]
+        })
+    }
 
-                let _ = command.create_followup(&ctx.http, response).await;
-            };
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
 
-            if config.logs.show_log_on_edit {
-                let message_link = format!(
-                    "https://discord.com/channels/{}/{}/{}",
-                    config.bot.get_staff_guild_id(),
-                    command.channel_id.get(),
-                    inbox_message_id
-                );
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
 
-                let mut params = HashMap::new();
-                params.insert(
-                    "before".to_string(),
-                    if before_content.is_empty() {
-                        "(inconnu)".to_string()
-                    } else {
-                        format!("`{}`", before_content.clone())
-                    },
-                );
-                params.insert("after".to_string(), format!("`{}`", new_content.clone()));
-                params.insert("link".to_string(), message_link);
+            defer_response(&ctx, &command).await?;
 
-                let response = MessageBuilder::system_message(ctx, config)
-                    .translated_content(
-                        "edit.modification_from_staff",
-                        Some(&params),
-                        Some(command.user.id),
-                        Some(config.bot.get_staff_guild_id()),
-                    )
-                    .await
-                    .to_channel(command.channel_id)
-                    .build_interaction_message_followup()
-                    .await;
+            let mut msg_id: i64 = 0;
+            let mut new_content: String = String::new();
 
-                let _ = command.create_followup(&ctx.http, response).await;
+            for option in command.data.options.iter() {
+                match option.name.as_str() {
+                    "message_id" => {
+                        if let CommandDataOptionValue::Integer(value) = &option.value {
+                            msg_id = *value;
+                        }
+                    }
+                    "message" => {
+                        if let CommandDataOptionValue::String(value) = &option.value {
+                            new_content = value.clone();
+                        }
+                    }
+                    _ => {}
+                }
             }
 
-            match update_message_content(&dm_msg_id, &new_content, pool).await {
+            match validate_edit_permissions(msg_id, command.channel_id, command.user.id, pool).await
+            {
                 Ok(()) => (),
                 Err(e) => return Err(e),
-            }
+            };
 
-            Ok(())
-        }
-        Err(e) => Err(e),
+            let ids = match get_message_ids(msg_id, command.user.id, pool, &ctx, command.channel_id)
+                .await
+            {
+                Ok(ids) => ids,
+                Err(e) => return Err(e),
+            };
+
+            let dm_msg_id = match ids.dm_message_id {
+                Some(msg_id) => msg_id,
+                None => return Err(message_not_found("Inbox message ID not found")),
+            };
+
+            let inbox_message_id = match ids.inbox_message_id {
+                Some(msg_id) => msg_id,
+                None => return Err(message_not_found("DM message ID not found")),
+            };
+
+            let edited_messages_builder = match format_new_message(
+                &ctx,
+                (None, Some(&command)),
+                &new_content,
+                &inbox_message_id,
+                msg_id as u64,
+                &config,
+                pool,
+            )
+            .await
+            {
+                Ok(edited_messages) => edited_messages,
+                Err(e) => return Err(e),
+            };
+
+            let before_content: String =
+                match get_thread_message_by_inbox_message_id(&inbox_message_id, pool).await {
+                    Ok(tm) => tm.content,
+                    Err(_) => String::new(),
+                };
+
+            let edit_result = edit_messages(
+                &ctx,
+                command.channel_id,
+                dm_msg_id.clone(),
+                inbox_message_id.clone(),
+                edited_messages_builder,
+                pool,
+                &config,
+            )
+            .await;
+
+            match edit_result {
+                Ok(()) => {
+                    if config.notifications.show_success_on_edit {
+                        let response = MessageBuilder::system_message(&ctx, &config)
+                            .translated_content(
+                                "success.message_edited",
+                                None,
+                                Some(command.user.id),
+                                command.guild_id.map(|g| g.get()),
+                            )
+                            .await
+                            .color(hex_string_to_int(&config.thread.system_message_color) as u32)
+                            .to_channel(command.channel_id)
+                            .build_interaction_message_followup()
+                            .await;
+
+                        let _ = command.create_followup(&ctx.http, response).await;
+                    };
+
+                    if config.logs.show_log_on_edit {
+                        let message_link = format!(
+                            "https://discord.com/channels/{}/{}/{}",
+                            config.bot.get_staff_guild_id(),
+                            command.channel_id.get(),
+                            inbox_message_id
+                        );
+
+                        let mut params = HashMap::new();
+                        params.insert(
+                            "before".to_string(),
+                            if before_content.is_empty() {
+                                "(inconnu)".to_string()
+                            } else {
+                                format!("`{}`", before_content.clone())
+                            },
+                        );
+                        params.insert("after".to_string(), format!("`{}`", new_content.clone()));
+                        params.insert("link".to_string(), message_link);
+
+                        let response = MessageBuilder::system_message(&ctx, &config)
+                            .translated_content(
+                                "edit.modification_from_staff",
+                                Some(&params),
+                                Some(command.user.id),
+                                Some(config.bot.get_staff_guild_id()),
+                            )
+                            .await
+                            .to_channel(command.channel_id)
+                            .build_interaction_message_followup()
+                            .await;
+
+                        let _ = command.create_followup(&ctx.http, response).await;
+                    }
+
+                    match update_message_content(&dm_msg_id, &new_content, pool).await {
+                        Ok(()) => (),
+                        Err(e) => return Err(e),
+                    }
+
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        })
     }
 }

--- a/src/commands/force_close/slash_command/force_close.rs
+++ b/src/commands/force_close/slash_command/force_close.rs
@@ -1,70 +1,91 @@
 use crate::commands::force_close::common::delete_channel;
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::threads::{is_a_ticket_channel, is_orphaned_thread_channel};
 use crate::errors::DatabaseError::QueryFailed;
 use crate::errors::ThreadError::{NotAThreadChannel, UserStillInServer};
-use crate::errors::{ModmailError, ModmailResult, common};
+use crate::errors::{common, ModmailError, ModmailResult};
 use crate::i18n::get_translated_message;
 use serenity::all::{CommandInteraction, Context, CreateCommand, ResolvedOption};
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.force_close_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct ForceCloseCommand;
 
-    CreateCommand::new("force_close").description(cmd_desc)
-}
+#[async_trait::async_trait]
+impl RegistrableCommand for ForceCloseCommand {
+    fn name(&self) -> &'static str {
+        "force_close"
+    }
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let db_pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    if !is_a_ticket_channel(command.channel_id, db_pool).await {
-        match command.channel_id.to_channel(&ctx.http).await {
-            Ok(channel) => {
-                let guild_channel = match channel.guild() {
-                    Some(guild_channel) => guild_channel,
-                    None => {
-                        return Err(ModmailError::Thread(NotAThreadChannel));
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.force_close_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+            vec![CreateCommand::new("force_close").description(cmd_desc)]
+        })
+    }
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let db_pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            if !is_a_ticket_channel(command.channel_id, db_pool).await {
+                match command.channel_id.to_channel(&ctx.http).await {
+                    Ok(channel) => {
+                        let guild_channel = match channel.guild() {
+                            Some(guild_channel) => guild_channel,
+                            None => {
+                                return Err(ModmailError::Thread(NotAThreadChannel));
+                            }
+                        };
+
+                        if let Some(category_id) = guild_channel.parent_id {
+                            if category_id == config.thread.inbox_category_id {
+                                delete_channel(&ctx, command.channel_id).await?;
+                            } else {
+                                return Err(ModmailError::Thread(NotAThreadChannel));
+                            }
+                        }
                     }
-                };
-
-                if let Some(category_id) = guild_channel.parent_id {
-                    if category_id == config.thread.inbox_category_id {
-                        delete_channel(ctx, command.channel_id).await?;
-                    } else {
+                    Err(_) => {
                         return Err(ModmailError::Thread(NotAThreadChannel));
                     }
                 }
             }
-            Err(_) => {
-                return Err(ModmailError::Thread(NotAThreadChannel));
-            }
-        }
-    }
 
-    match is_orphaned_thread_channel(command.channel_id, db_pool).await {
-        Ok(res) => {
-            if !res {
-                return Err(ModmailError::Thread(UserStillInServer));
+            match is_orphaned_thread_channel(command.channel_id, db_pool).await {
+                Ok(res) => {
+                    if !res {
+                        return Err(ModmailError::Thread(UserStillInServer));
+                    }
+                    delete_channel(&ctx, command.channel_id).await
+                }
+                Err(..) => Err(ModmailError::Database(QueryFailed(
+                    "Failed to check if thread channel is orphaned".to_string(),
+                ))),
             }
-            delete_channel(ctx, command.channel_id).await
-        }
-        Err(..) => Err(ModmailError::Database(QueryFailed(
-            "Failed to check if thread channel is orphaned".to_string(),
-        ))),
+        })
     }
 }

--- a/src/commands/help/slash_command/help.rs
+++ b/src/commands/help/slash_command/help.rs
@@ -1,3 +1,4 @@
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::errors::ModmailResult;
 use crate::i18n::get_translated_message;
@@ -5,50 +6,70 @@ use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::{CommandInteraction, Context, CreateCommand, ResolvedOption};
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.help_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct HelpCommand;
 
-    CreateCommand::new("help").description(cmd_desc)
-}
+#[async_trait::async_trait]
+impl RegistrableCommand for HelpCommand {
+    fn name(&self) -> &'static str {
+        "help"
+    }
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let help_message = "# Available commands:\n\n\
-        **!add_staff <staff_id>** - Add a staff to an hidden ticket\n\
-        **!remove_staff <staff_id>** - Remove a staff from a ticket\n\
-        **!alert** - Alert staff in the current thread when a new user answer arrives \n\
-        **!help** - Show this help message\n\
-        **!reply <message>** - Reply to a ticket\n\
-        **!annonreply <message>** - Reply anonymously to a ticket\n\
-        **!close [reason]** - Close the current thread with an optional reason\n\
-        **!delete [reason]** - Delete the current thread with an optional reason\n\
-        **!hide** - Make the current thread hidden to non-staff members\n\
-        **!new_thread <user_id>** - Create a new ticket with a specific user\n\
-        **!alert [cancel]** - Set or cancel an alert for staff in the current thread\n\
-        **!force_close** - Force close the current thread if it's orphaned\n\
-        **!id** - Show the user ID associated with the current thread";
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    defer_response(&ctx, &command).await?;
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.help_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let response = MessageBuilder::system_message(ctx, config)
-        .content(help_message)
-        .to_channel(command.channel_id)
-        .build_interaction_message_followup()
-        .await;
+            vec![CreateCommand::new("help").description(cmd_desc)]
+        })
+    }
 
-    let _ = command.create_followup(&ctx.http, response).await;
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
 
-    Ok(())
+        Box::pin(async move {
+            let help_message = "# Available commands:\n\n\
+                **!add_staff <staff_id>** - Add a staff to an hidden ticket\n\
+                **!remove_staff <staff_id>** - Remove a staff from a ticket\n\
+                **!alert** - Alert staff in the current thread when a new user answer arrives \n\
+                **!help** - Show this help message\n\
+                **!reply <message>** - Reply to a ticket\n\
+                **!annonreply <message>** - Reply anonymously to a ticket\n\
+                **!close [reason]** - Close the current thread with an optional reason\n\
+                **!delete [reason]** - Delete the current thread with an optional reason\n\
+                **!hide** - Make the current thread hidden to non-staff members\n\
+                **!new_thread <user_id>** - Create a new ticket with a specific user\n\
+                **!alert [cancel]** - Set or cancel an alert for staff in the current thread\n\
+                **!force_close** - Force close the current thread if it's orphaned\n\
+                **!id** - Show the user ID associated with the current thread";
+
+            defer_response(&ctx, &command).await?;
+
+            let response = MessageBuilder::system_message(&ctx, &config)
+                .content(help_message)
+                .to_channel(command.channel_id)
+                .build_interaction_message_followup()
+                .await;
+
+            let _ = command.create_followup(&ctx.http, response).await;
+
+            Ok(())
+        })
+    }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,10 @@
+use crate::config::Config;
+use crate::errors::ModmailResult;
+use serenity::all::{CommandInteraction, Context, CreateCommand, ResolvedOption};
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
 pub mod add_staff;
 pub mod alert;
 pub mod anonreply;
@@ -12,3 +19,43 @@ pub mod new_thread;
 pub mod recover;
 pub mod remove_staff;
 pub mod reply;
+
+pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+pub trait RegistrableCommand: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>>;
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>>;
+}
+
+pub struct CommandRegistry {
+    commands: HashMap<&'static str, Arc<dyn RegistrableCommand>>,
+}
+
+impl CommandRegistry {
+    pub fn new() -> Self {
+        Self {
+            commands: HashMap::new(),
+        }
+    }
+
+    pub fn register_command<C: RegistrableCommand + 'static>(&mut self, command: C) {
+        self.commands.insert(command.name(), Arc::new(command));
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn RegistrableCommand>> {
+        self.commands.get(name).cloned()
+    }
+
+    pub fn all(&self) -> Vec<Arc<dyn RegistrableCommand>> {
+        self.commands.values().cloned().collect()
+    }
+}

--- a/src/commands/move_thread/slash_command/move_thread.rs
+++ b/src/commands/move_thread/slash_command/move_thread.rs
@@ -1,6 +1,7 @@
 use crate::commands::move_thread::common::{
     fetch_server_categories, find_best_match_category, move_channel_to_category_by_command_option,
 };
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::get_user_id_from_channel_id;
 use crate::errors::{
@@ -15,112 +16,139 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.move_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let catagory_field_desc = get_translated_message(
-        config,
-        "slash_command.move_command_name_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct MoveCommand;
 
-    CreateCommand::new("move").description(cmd_desc).add_option(
-        CreateCommandOption::new(CommandOptionType::String, "category", catagory_field_desc)
-            .required(true),
-    )
-}
-
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = match &config.db_pool {
-        Some(pool) => pool,
-        None => {
-            return Err(ModmailError::Database(DatabaseError::ConnectionFailed));
-        }
-    };
-
-    defer_response(&ctx, &command).await?;
-
-    if !get_user_id_from_channel_id(&command.channel_id.to_string(), pool)
-        .await
-        .is_some()
-    {
-        return Err(ModmailError::Command(CommandError::NotInThread()));
+#[async_trait::async_trait]
+impl RegistrableCommand for MoveCommand {
+    fn name(&self) -> &'static str {
+        "move"
     }
 
-    let category_name = match command
-        .data
-        .options
-        .iter()
-        .find(|opt| opt.name == "category")
-    {
-        Some(opt) => match &opt.value {
-            serenity::all::CommandDataOptionValue::String(name) => name.trim().to_string(),
-            _ => String::new(),
-        },
-        None => String::new(),
-    };
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    if category_name.is_empty() {
-        return Err(ModmailError::Thread(ThreadError::CategoryNotFound));
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.move_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let catagory_field_desc = get_translated_message(
+                &config,
+                "slash_command.move_command_name_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+            vec![
+                CreateCommand::new("move").description(cmd_desc).add_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "category",
+                        catagory_field_desc,
+                    )
+                    .required(true),
+                ),
+            ]
+        })
     }
 
-    let categories = fetch_server_categories(ctx, config).await;
-    if categories.is_empty() {
-        return Err(ModmailError::Discord(DiscordError::FailedToFetchCategories));
-    }
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
 
-    let target_category = find_best_match_category(&category_name, &categories);
+        Box::pin(async move {
+            let pool = match &config.db_pool {
+                Some(pool) => pool,
+                None => {
+                    return Err(ModmailError::Database(DatabaseError::ConnectionFailed));
+                }
+            };
 
-    match target_category {
-        Some((category_id, category_name)) => {
-            if let Err(e) =
-                move_channel_to_category_by_command_option(ctx, command, category_id).await
+            defer_response(&ctx, &command).await?;
+
+            if !get_user_id_from_channel_id(&command.channel_id.to_string(), pool)
+                .await
+                .is_some()
             {
-                eprintln!("Failed to move channel: {}", e);
-                return Err(ModmailError::Discord(DiscordError::FailedToMoveChannel));
+                return Err(ModmailError::Command(CommandError::NotInThread()));
             }
 
-            let mut params = HashMap::new();
-            params.insert("category".to_string(), category_name.to_string());
-            params.insert("staff".to_string(), command.user.name.clone());
+            let category_name = match command
+                .data
+                .options
+                .iter()
+                .find(|opt| opt.name == "category")
+            {
+                Some(opt) => match &opt.value {
+                    serenity::all::CommandDataOptionValue::String(name) => name.trim().to_string(),
+                    _ => String::new(),
+                },
+                None => String::new(),
+            };
 
-            let response = MessageBuilder::system_message(&ctx, &config)
-                .translated_content(
-                    "move_thread.success",
-                    Some(&params),
-                    Some(command.user.id),
-                    command.guild_id.map(|g| g.get()),
-                )
-                .await
-                .to_channel(command.channel_id)
-                .build_interaction_message_followup()
-                .await;
+            if category_name.is_empty() {
+                return Err(ModmailError::Thread(ThreadError::CategoryNotFound));
+            }
 
-            command.create_followup(&ctx.http, response).await?;
+            let categories = fetch_server_categories(&ctx, &config).await;
+            if categories.is_empty() {
+                return Err(ModmailError::Discord(DiscordError::FailedToFetchCategories));
+            }
 
-            Ok(())
-        }
-        None => {
-            let mut params = HashMap::new();
-            params.insert("category".to_string(), category_name);
+            let target_category = find_best_match_category(&category_name, &categories);
 
-            Err(ModmailError::Thread(ThreadError::CategoryNotFound))
-        }
+            match target_category {
+                Some((category_id, category_name)) => {
+                    if let Err(e) =
+                        move_channel_to_category_by_command_option(&ctx, &command, category_id)
+                            .await
+                    {
+                        eprintln!("Failed to move channel: {}", e);
+                        return Err(ModmailError::Discord(DiscordError::FailedToMoveChannel));
+                    }
+
+                    let mut params = HashMap::new();
+                    params.insert("category".to_string(), category_name.to_string());
+                    params.insert("staff".to_string(), command.user.name.clone());
+
+                    let response = MessageBuilder::system_message(&ctx, &config)
+                        .translated_content(
+                            "move_thread.success",
+                            Some(&params),
+                            Some(command.user.id),
+                            command.guild_id.map(|g| g.get()),
+                        )
+                        .await
+                        .to_channel(command.channel_id)
+                        .build_interaction_message_followup()
+                        .await;
+
+                    command.create_followup(&ctx.http, response).await?;
+
+                    Ok(())
+                }
+                None => {
+                    let mut params = HashMap::new();
+                    params.insert("category".to_string(), category_name);
+
+                    Err(ModmailError::Thread(ThreadError::CategoryNotFound))
+                }
+            }
+        })
     }
 }

--- a/src/commands/new_thread/slash_command/new_thread.rs
+++ b/src/commands/new_thread/slash_command/new_thread.rs
@@ -1,8 +1,9 @@
 use crate::commands::new_thread::common::send_welcome_message;
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::{create_thread_for_user, get_thread_channel_by_user_id, thread_exists};
 use crate::errors::{
-    CommandError, DatabaseError, DiscordError, ModmailError, ModmailResult, common,
+    common, CommandError, DatabaseError, DiscordError, ModmailError, ModmailResult,
 };
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
@@ -13,142 +14,171 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.new_thread_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct NewThreadCommand;
 
-    let user_id_desc = get_translated_message(
-        config,
-        "slash_command.new_thread_user_id_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+#[async_trait::async_trait]
+impl RegistrableCommand for NewThreadCommand {
+    fn name(&self) -> &'static str {
+        "new_thread"
+    }
 
-    CreateCommand::new("new_thread")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
-                .required(true),
-        )
-}
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.new_thread_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    defer_response(&ctx, &command).await?;
+            let user_id_desc = get_translated_message(
+                &config,
+                "slash_command.new_thread_user_id_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let user_id = match command
-        .data
-        .options
-        .iter()
-        .find(|opt| opt.name == "user_id")
-    {
-        Some(opt) => match &opt.value {
-            CommandDataOptionValue::User(user_id) => *user_id,
-            _ => {
-                return Err(ModmailError::Command(CommandError::InvalidArguments(
-                    "user_id".to_string(),
-                )));
+            vec![
+                CreateCommand::new("new_thread")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
+                            .required(true),
+                    ),
+            ]
+        })
+    }
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            let user_id = match command
+                .data
+                .options
+                .iter()
+                .find(|opt| opt.name == "user_id")
+            {
+                Some(opt) => match &opt.value {
+                    CommandDataOptionValue::User(user_id) => *user_id,
+                    _ => {
+                        return Err(ModmailError::Command(CommandError::InvalidArguments(
+                            "user_id".to_string(),
+                        )));
+                    }
+                },
+                None => return Err(ModmailError::Command(CommandError::MissingArguments)),
+            };
+
+            let user = match ctx.http.get_user(user_id).await {
+                Ok(user) => user,
+                Err(_) => return Err(ModmailError::Discord(DiscordError::UserNotFound)),
+            };
+
+            if user.bot {
+                return Err(ModmailError::Discord(DiscordError::UserIsABot));
             }
-        },
-        None => return Err(ModmailError::Command(CommandError::MissingArguments)),
-    };
 
-    let user = match ctx.http.get_user(user_id).await {
-        Ok(user) => user,
-        Err(_) => return Err(ModmailError::Discord(DiscordError::UserNotFound)),
-    };
+            if thread_exists(user_id, pool).await {
+                return if let Some(channel_id_str) =
+                    get_thread_channel_by_user_id(user_id, pool).await
+                {
+                    Err(ModmailError::Command(
+                        CommandError::UserHasAlreadyAThreadWithLink(
+                            user.name.clone(),
+                            channel_id_str.clone(),
+                        ),
+                    ))
+                } else {
+                    Err(ModmailError::Command(CommandError::UserHasAlreadyAThread()))
+                };
+            }
 
-    if user.bot {
-        return Err(ModmailError::Discord(DiscordError::UserIsABot));
+            let inbox_category_id = ChannelId::new(config.thread.inbox_category_id);
+            let channel_name = user.name.to_lowercase().replace(" ", "-").to_string();
+            let mut channel_builder = serenity::all::CreateChannel::new(&channel_name);
+            channel_builder = channel_builder
+                .kind(serenity::model::channel::ChannelType::Text)
+                .category(inbox_category_id);
+
+            let staff_guild_id = GuildId::new(config.bot.get_staff_guild_id());
+            let guild_channel = match staff_guild_id
+                .create_channel(&ctx.http, channel_builder)
+                .await
+            {
+                Ok(channel) => channel,
+                Err(e) => {
+                    eprintln!("Failed to create channel: {}", e);
+                    return Err(ModmailError::Discord(DiscordError::ChannelCreationFailed));
+                }
+            };
+
+            let _ = match create_thread_for_user(
+                &guild_channel,
+                user_id.get() as i64,
+                &user.name,
+                pool,
+            )
+            .await
+            {
+                Ok(thread_id) => thread_id,
+                Err(e) => {
+                    eprintln!("Failed to create thread in database: {}", e);
+                    let _ = guild_channel.delete(&ctx.http).await;
+                    return Err(ModmailError::Database(DatabaseError::InsertFailed(
+                        e.to_string(),
+                    )));
+                }
+            };
+
+            send_welcome_message(&ctx, &guild_channel, &config, &user).await;
+
+            let mut params = HashMap::new();
+            params.insert("user".to_string(), user.name.clone());
+            params.insert("channel_id".to_string(), guild_channel.to_string());
+            params.insert("staff".to_string(), command.user.name.clone());
+
+            println!(
+                "Thread created for user {} in channel {}",
+                user.name,
+                guild_channel.to_string()
+            );
+
+            let response = MessageBuilder::system_message(&ctx, &config)
+                .translated_content("new_thread.success_with_dm", Some(&params), None, None)
+                .await
+                .to_channel(command.channel_id)
+                .build_interaction_message_followup()
+                .await;
+
+            let _ = command
+                .create_followup(&ctx.http, CreateInteractionResponseFollowup::from(response))
+                .await?;
+
+            Ok(())
+        })
     }
-
-    if thread_exists(user_id, pool).await {
-        return if let Some(channel_id_str) = get_thread_channel_by_user_id(user_id, pool).await {
-            Err(ModmailError::Command(
-                CommandError::UserHasAlreadyAThreadWithLink(
-                    user.name.clone(),
-                    channel_id_str.clone(),
-                ),
-            ))
-        } else {
-            Err(ModmailError::Command(CommandError::UserHasAlreadyAThread()))
-        };
-    }
-
-    let inbox_category_id = ChannelId::new(config.thread.inbox_category_id);
-    let channel_name = user.name.to_lowercase().replace(" ", "-").to_string();
-    let mut channel_builder = serenity::all::CreateChannel::new(&channel_name);
-    channel_builder = channel_builder
-        .kind(serenity::model::channel::ChannelType::Text)
-        .category(inbox_category_id);
-
-    let staff_guild_id = GuildId::new(config.bot.get_staff_guild_id());
-    let guild_channel = match staff_guild_id
-        .create_channel(&ctx.http, channel_builder)
-        .await
-    {
-        Ok(channel) => channel,
-        Err(e) => {
-            eprintln!("Failed to create channel: {}", e);
-            return Err(ModmailError::Discord(DiscordError::ChannelCreationFailed));
-        }
-    };
-
-    let _ = match create_thread_for_user(&guild_channel, user_id.get() as i64, &user.name, pool)
-        .await
-    {
-        Ok(thread_id) => thread_id,
-        Err(e) => {
-            eprintln!("Failed to create thread in database: {}", e);
-            let _ = guild_channel.delete(&ctx.http).await;
-            return Err(ModmailError::Database(DatabaseError::InsertFailed(
-                e.to_string(),
-            )));
-        }
-    };
-
-    send_welcome_message(ctx, &guild_channel, config, &user).await;
-
-    let mut params = HashMap::new();
-    params.insert("user".to_string(), user.name.clone());
-    params.insert("channel_id".to_string(), guild_channel.to_string());
-    params.insert("staff".to_string(), command.user.name.clone());
-
-    println!(
-        "Thread created for user {} in channel {}",
-        user.name,
-        guild_channel.to_string()
-    );
-
-    let response = MessageBuilder::system_message(ctx, config)
-        .translated_content("new_thread.success_with_dm", Some(&params), None, None)
-        .await
-        .to_channel(command.channel_id)
-        .build_interaction_message_followup()
-        .await;
-
-    let _ = command
-        .create_followup(&ctx.http, CreateInteractionResponseFollowup::from(response))
-        .await?;
-
-    Ok(())
 }

--- a/src/commands/recover/slash_command/recover.rs
+++ b/src/commands/recover/slash_command/recover.rs
@@ -1,5 +1,6 @@
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::errors::{ModmailResult, common};
+use crate::errors::{common, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::modules::message_recovery::recover_missing_messages;
 use crate::utils::command::defer_response::defer_response;
@@ -7,78 +8,98 @@ use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::{CommandInteraction, Context, CreateCommand, ResolvedOption};
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.recover_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct RecoverCommand;
 
-    CreateCommand::new("recover").description(cmd_desc)
-}
+#[async_trait::async_trait]
+impl RegistrableCommand for RecoverCommand {
+    fn name(&self) -> &'static str {
+        "recover"
+    }
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let _ = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-    defer_response(&ctx, &command).await?;
-
-    let mut params = HashMap::new();
-    params.insert("user".to_string(), command.user.name.clone());
-
-    let response = MessageBuilder::system_message(ctx, config)
-        .translated_content(
-            "recovery.started",
-            Some(&params),
-            Some(command.user.id),
-            command.guild_id.map(|g| g.get()),
-        )
-        .await
-        .to_channel(command.channel_id)
-        .build_interaction_message_followup()
-        .await;
-
-    let _ = command.create_followup(&ctx.http, response).await;
-
-    let ctx_clone = ctx.clone();
-    let config_clone = config.clone();
-    let channel_id = command.channel_id;
-    let command_clone = command.clone();
-
-    tokio::spawn(async move {
-        let recovery_results = recover_missing_messages(&ctx_clone, &config_clone).await;
-
-        let total_recovered: u32 = recovery_results.iter().map(|r| r.recovered_count).sum();
-        let successful_threads = recovery_results.iter().filter(|r| r.success).count();
-        let failed_threads = recovery_results.len() - successful_threads;
-
-        let mut params = HashMap::new();
-        params.insert("total".to_string(), total_recovered.to_string());
-        params.insert("threads".to_string(), successful_threads.to_string());
-        params.insert("failed".to_string(), failed_threads.to_string());
-
-        let response = MessageBuilder::system_message(&ctx_clone, &config_clone)
-            .translated_content("recovery.summary", Some(&params), None, None)
-            .await
-            .to_channel(channel_id)
-            .build_interaction_message_followup()
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.recover_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
             .await;
 
-        let _ = command_clone
-            .create_followup(&ctx_clone.http, response)
-            .await;
-    });
+            vec![CreateCommand::new("recover").description(cmd_desc)]
+        })
+    }
 
-    Ok(())
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let _ = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            let mut params = HashMap::new();
+            params.insert("user".to_string(), command.user.name.clone());
+
+            let response = MessageBuilder::system_message(&ctx, &config)
+                .translated_content(
+                    "recovery.started",
+                    Some(&params),
+                    Some(command.user.id),
+                    command.guild_id.map(|g| g.get()),
+                )
+                .await
+                .to_channel(command.channel_id)
+                .build_interaction_message_followup()
+                .await;
+
+            let _ = command.create_followup(&ctx.http, response).await;
+
+            let ctx_clone = ctx.clone();
+            let config_clone = config.clone();
+            let channel_id = command.channel_id;
+            let command_clone = command.clone();
+
+            tokio::spawn(async move {
+                let recovery_results = recover_missing_messages(&ctx_clone, &config_clone).await;
+
+                let total_recovered: u32 = recovery_results.iter().map(|r| r.recovered_count).sum();
+                let successful_threads = recovery_results.iter().filter(|r| r.success).count();
+                let failed_threads = recovery_results.len() - successful_threads;
+
+                let mut params = HashMap::new();
+                params.insert("total".to_string(), total_recovered.to_string());
+                params.insert("threads".to_string(), successful_threads.to_string());
+                params.insert("failed".to_string(), failed_threads.to_string());
+
+                let response = MessageBuilder::system_message(&ctx_clone, &config_clone)
+                    .translated_content("recovery.summary", Some(&params), None, None)
+                    .await
+                    .to_channel(channel_id)
+                    .build_interaction_message_followup()
+                    .await;
+
+                let _ = command_clone
+                    .create_followup(&ctx_clone.http, response)
+                    .await;
+            });
+
+            Ok(())
+        })
+    }
 }

--- a/src/commands/remove_staff/slash_command/remove_staff.rs
+++ b/src/commands/remove_staff/slash_command/remove_staff.rs
@@ -1,9 +1,10 @@
 use crate::commands::remove_staff::common::remove_user_from_channel;
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::thread_exists;
 use crate::errors::CommandError::InvalidFormat;
 use crate::errors::ThreadError::NotAThreadChannel;
-use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
@@ -13,87 +14,117 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.remove_staff_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct RemoveStaffCommand;
 
-    let user_id_desc = get_translated_message(
-        config,
-        "slash_command.remove_staff_user_id_argument",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+#[async_trait::async_trait]
+impl RegistrableCommand for RemoveStaffCommand {
+    fn name(&self) -> &'static str {
+        "remove_staff"
+    }
 
-    CreateCommand::new("remove_staff")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
-                .required(true),
-        )
-}
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
 
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.remove_staff_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    defer_response(&ctx, &command).await?;
+            let user_id_desc = get_translated_message(
+                &config,
+                "slash_command.remove_staff_user_id_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
-    let user_id = match command
-        .data
-        .options
-        .iter()
-        .find(|opt| opt.name == "user_id")
-    {
-        Some(opt) => match &opt.value {
-            CommandDataOptionValue::User(user_id) => *user_id,
-            _ => {
-                return Err(ModmailError::Command(CommandError::InvalidArguments(
-                    "user_id".to_string(),
-                )));
+            vec![
+                CreateCommand::new("remove_staff")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
+                            .required(true),
+                    ),
+            ]
+        })
+    }
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            let user_id = match command
+                .data
+                .options
+                .iter()
+                .find(|opt| opt.name == "user_id")
+            {
+                Some(opt) => match &opt.value {
+                    CommandDataOptionValue::User(user_id) => *user_id,
+                    _ => {
+                        return Err(ModmailError::Command(CommandError::InvalidArguments(
+                            "user_id".to_string(),
+                        )));
+                    }
+                },
+                None => return Err(ModmailError::Command(CommandError::MissingArguments)),
+            };
+
+            if thread_exists(command.user.id, pool).await {
+                match remove_user_from_channel(&ctx, command.channel_id, user_id).await {
+                    Ok(_) => {
+                        let mut params = HashMap::new();
+                        params.insert("user".to_string(), format!("<@{}>", user_id));
+
+                        let response = MessageBuilder::system_message(&ctx, &config)
+                            .translated_content(
+                                "add_staff.remove_success",
+                                Some(&params),
+                                None,
+                                None,
+                            )
+                            .await
+                            .to_channel(command.channel_id)
+                            .build_interaction_message_followup()
+                            .await;
+
+                        let _ = command
+                            .create_followup(
+                                &ctx.http,
+                                CreateInteractionResponseFollowup::from(response),
+                            )
+                            .await;
+
+                        Ok(())
+                    }
+                    Err(..) => Err(ModmailError::Command(InvalidFormat)),
+                }
+            } else {
+                Err(ModmailError::Thread(NotAThreadChannel))
             }
-        },
-        None => return Err(ModmailError::Command(CommandError::MissingArguments)),
-    };
-
-    if thread_exists(command.user.id, pool).await {
-        match remove_user_from_channel(ctx, command.channel_id, user_id).await {
-            Ok(_) => {
-                let mut params = HashMap::new();
-                params.insert("user".to_string(), format!("<@{}>", user_id));
-
-                let response = MessageBuilder::system_message(ctx, config)
-                    .translated_content("add_staff.remove_success", Some(&params), None, None)
-                    .await
-                    .to_channel(command.channel_id)
-                    .build_interaction_message_followup()
-                    .await;
-
-                let _ = command
-                    .create_followup(&ctx.http, CreateInteractionResponseFollowup::from(response))
-                    .await;
-
-                Ok(())
-            }
-            Err(..) => Err(ModmailError::Command(InvalidFormat)),
-        }
-    } else {
-        Err(ModmailError::Thread(NotAThreadChannel))
+        })
     }
 }

--- a/src/commands/reply/slash_command/reply.rs
+++ b/src/commands/reply/slash_command/reply.rs
@@ -1,11 +1,12 @@
+use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::allocate_next_message_number;
 use crate::errors::MessageError::MessageEmpty;
-use crate::errors::{CommandError, ModmailError, ModmailResult, ThreadError, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult, ThreadError};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
-use crate::utils::message::reply_intent::{ReplyIntent, extract_intent};
+use crate::utils::message::reply_intent::{extract_intent, ReplyIntent};
 use crate::utils::thread::fetch_thread::fetch_thread;
 use serenity::all::{
     Attachment, CommandDataOptionValue, CommandInteraction, CommandOptionType, Context,
@@ -13,171 +14,197 @@ use serenity::all::{
 };
 use std::collections::HashMap;
 
-pub async fn register(config: &Config) -> CreateCommand {
-    let cmd_desc = get_translated_message(
-        config,
-        "slash_command.reply_command_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let message_desc = get_translated_message(
-        config,
-        "slash_command.reply_message_argument_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let attachments_desc = get_translated_message(
-        config,
-        "slash_command.reply_attachment_argument_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
-    let anonymous_desc = get_translated_message(
-        config,
-        "slash_command.reply_anonymous_argument_description",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await;
+pub struct ReplyCommand;
 
-    CreateCommand::new("reply")
-        .description(cmd_desc)
-        .add_option(
-            CreateCommandOption::new(CommandOptionType::String, "message", message_desc)
-                .required(true),
-        )
-        .add_option(
-            CreateCommandOption::new(
-                CommandOptionType::Attachment,
-                "attachment",
-                attachments_desc,
+#[async_trait::async_trait]
+impl RegistrableCommand for ReplyCommand {
+    fn name(&self) -> &'static str {
+        "reply"
+    }
+
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
+
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.reply_command_description",
+                None,
+                None,
+                None,
+                None,
             )
-            .required(false),
-        )
-        .add_option(CreateCommandOption::new(
-            CommandOptionType::Boolean,
-            "anonymous",
-            anonymous_desc,
-        ))
-}
-
-pub async fn run(
-    ctx: &Context,
-    command: &CommandInteraction,
-    _options: &[ResolvedOption<'_>],
-    config: &Config,
-) -> ModmailResult<()> {
-    let db_pool = config
-        .db_pool
-        .as_ref()
-        .ok_or_else(common::database_connection_failed)?;
-
-    defer_response(&ctx, &command).await?;
-
-    let mut content: Option<String> = None;
-    let mut attachments: Vec<Attachment> = Vec::new();
-    let mut anonymous: bool = false;
-
-    for option in &command.data.options {
-        match &option.value {
-            CommandDataOptionValue::String(val) if option.name == "message" => {
-                content = Some(val.clone());
-            }
-            CommandDataOptionValue::Attachment(att_id) if option.name == "attachment" => {
-                if let Some(att) = command.data.resolved.attachments.get(att_id) {
-                    attachments.push(att.clone());
-                }
-            }
-            CommandDataOptionValue::Boolean(anonym) if option.name == "anonymous" => {
-                anonymous = *anonym;
-            }
-            _ => {}
-        }
-    }
-
-    let intent = extract_intent(content, &attachments).await;
-
-    let Some(intent) = intent else {
-        return Err(ModmailError::Message(MessageEmpty));
-    };
-
-    let thread = fetch_thread(db_pool, &command.channel_id.to_string()).await?;
-    let user_id = UserId::new(thread.user_id as u64);
-    let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
-    let user_still_member = community_guild_id.member(&ctx.http, user_id).await.is_ok();
-
-    if !user_still_member {
-        return Err(ModmailError::Thread(ThreadError::UserNotInTheServer));
-    }
-
-    let next_message_number = allocate_next_message_number(&thread.id, db_pool)
-        .await
-        .map_err(|_| common::validation_failed("Failed to allocate message number"))?;
-
-    let mut sr = MessageBuilder::begin_staff_reply(
-        ctx,
-        config,
-        thread.id.clone(),
-        command.user.id,
-        command.user.name.clone(),
-        next_message_number,
-    )
-    .to_thread(command.channel_id)
-    .anonymous(anonymous)
-    .to_user(user_id);
-
-    match intent {
-        ReplyIntent::Text(text) => {
-            sr = sr.content(text);
-        }
-        ReplyIntent::Attachments(files) => {
-            sr = sr.add_attachments(files);
-        }
-        ReplyIntent::TextAndAttachments(text, files) => {
-            sr = sr.content(text).add_attachments(files);
-        }
-    }
-
-    let (_, dm_msg_opt) = match sr.send_command_and_record(command, db_pool).await {
-        Ok(tuple) => tuple,
-        Err(_) => {
-            return Err(common::validation_failed("Failed to send to thread"));
-        }
-    };
-
-    if dm_msg_opt.is_none() {
-        return Err(ModmailError::Command(CommandError::SendDmFailed));
-    }
-
-    if config.notifications.show_success_on_reply {
-        let mut params = HashMap::new();
-        params.insert("number".to_string(), next_message_number.to_string());
-
-        let response = MessageBuilder::system_message(ctx, config)
-            .translated_content(
-                "success.message_sent",
-                Some(&params),
-                Some(command.user.id),
-                command.guild_id.map(|g| g.get()),
+            .await;
+            let message_desc = get_translated_message(
+                &config,
+                "slash_command.reply_message_argument_description",
+                None,
+                None,
+                None,
+                None,
             )
-            .await
-            .to_channel(command.channel_id)
-            .build_interaction_message_followup()
+            .await;
+            let attachments_desc = get_translated_message(
+                &config,
+                "slash_command.reply_attachment_argument_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let anonymous_desc = get_translated_message(
+                &config,
+                "slash_command.reply_anonymous_argument_description",
+                None,
+                None,
+                None,
+                None,
+            )
             .await;
 
-        let _ = command.create_followup(&ctx.http, response).await;
+            vec![
+                CreateCommand::new("reply")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "message",
+                            message_desc,
+                        )
+                        .required(true),
+                    )
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::Attachment,
+                            "attachment",
+                            attachments_desc,
+                        )
+                        .required(false),
+                    )
+                    .add_option(CreateCommandOption::new(
+                        CommandOptionType::Boolean,
+                        "anonymous",
+                        anonymous_desc,
+                    )),
+            ]
+        })
     }
 
-    Ok(())
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let db_pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            let mut content: Option<String> = None;
+            let mut attachments: Vec<Attachment> = Vec::new();
+            let mut anonymous: bool = false;
+
+            for option in &command.data.options {
+                match &option.value {
+                    CommandDataOptionValue::String(val) if option.name == "message" => {
+                        content = Some(val.clone());
+                    }
+                    CommandDataOptionValue::Attachment(att_id) if option.name == "attachment" => {
+                        if let Some(att) = command.data.resolved.attachments.get(att_id) {
+                            attachments.push(att.clone());
+                        }
+                    }
+                    CommandDataOptionValue::Boolean(anonym) if option.name == "anonymous" => {
+                        anonymous = *anonym;
+                    }
+                    _ => {}
+                }
+            }
+
+            let intent = extract_intent(content, &attachments).await;
+
+            let Some(intent) = intent else {
+                return Err(ModmailError::Message(MessageEmpty));
+            };
+
+            let thread = fetch_thread(db_pool, &command.channel_id.to_string()).await?;
+            let user_id = UserId::new(thread.user_id as u64);
+            let community_guild_id = GuildId::new(config.bot.get_community_guild_id());
+            let user_still_member = community_guild_id.member(&ctx.http, user_id).await.is_ok();
+
+            if !user_still_member {
+                return Err(ModmailError::Thread(ThreadError::UserNotInTheServer));
+            }
+
+            let next_message_number = allocate_next_message_number(&thread.id, db_pool)
+                .await
+                .map_err(|_| common::validation_failed("Failed to allocate message number"))?;
+
+            let mut sr = MessageBuilder::begin_staff_reply(
+                &ctx,
+                &config,
+                thread.id.clone(),
+                command.user.id,
+                command.user.name.clone(),
+                next_message_number,
+            )
+            .to_thread(command.channel_id)
+            .anonymous(anonymous)
+            .to_user(user_id);
+
+            match intent {
+                ReplyIntent::Text(text) => {
+                    sr = sr.content(text);
+                }
+                ReplyIntent::Attachments(files) => {
+                    sr = sr.add_attachments(files);
+                }
+                ReplyIntent::TextAndAttachments(text, files) => {
+                    sr = sr.content(text).add_attachments(files);
+                }
+            }
+
+            let (_, dm_msg_opt) = match sr.send_command_and_record(&command, db_pool).await {
+                Ok(tuple) => tuple,
+                Err(_) => {
+                    return Err(common::validation_failed("Failed to send to thread"));
+                }
+            };
+
+            if dm_msg_opt.is_none() {
+                return Err(ModmailError::Command(CommandError::SendDmFailed));
+            }
+
+            if config.notifications.show_success_on_reply {
+                let mut params = HashMap::new();
+                params.insert("number".to_string(), next_message_number.to_string());
+
+                let response = MessageBuilder::system_message(&ctx, &config)
+                    .translated_content(
+                        "success.message_sent",
+                        Some(&params),
+                        Some(command.user.id),
+                        command.guild_id.map(|g| g.get()),
+                    )
+                    .await
+                    .to_channel(command.channel_id)
+                    .build_interaction_message_followup()
+                    .await;
+
+                let _ = command.create_followup(&ctx.http, response).await;
+            }
+
+            Ok(())
+        })
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,17 @@
+use crate::commands::add_staff::slash_command::add_staff::AddStaffCommand;
+use crate::commands::alert::slash_command::alert::AlertCommand;
+use crate::commands::close::slash_command::close::CloseCommand;
+use crate::commands::delete::slash_command::delete::DeleteCommand;
+use crate::commands::edit::slash_command::edit::EditCommand;
+use crate::commands::force_close::slash_command::force_close::ForceCloseCommand;
+use crate::commands::help::slash_command::help::HelpCommand;
+use crate::commands::id::slash_command::id::IdCommand;
+use crate::commands::move_thread::slash_command::move_thread::MoveCommand;
+use crate::commands::new_thread::slash_command::new_thread::NewThreadCommand;
+use crate::commands::recover::slash_command::recover::RecoverCommand;
+use crate::commands::remove_staff::slash_command::remove_staff::RemoveStaffCommand;
+use crate::commands::reply::slash_command::reply::ReplyCommand;
+use crate::commands::CommandRegistry;
 use crate::handlers::guild_handler::GuildHandler;
 use crate::handlers::guild_interaction_handler::InteractionHandler;
 use crate::handlers::guild_message_reactions_handler::GuildMessageReactionsHandler;
@@ -11,6 +25,7 @@ use handlers::{
 use serenity::all::{ClientBuilder, GatewayIntents};
 use serenity::cache::Settings as CacheSettings;
 use std::process;
+use std::sync::Arc;
 use std::time::Duration;
 
 mod commands;
@@ -51,15 +66,32 @@ async fn main() {
     cache_settings.max_messages = 10_000;
     cache_settings.time_to_live = Duration::from_secs(6 * 60 * 60);
 
+    let mut registry = CommandRegistry::new();
+    registry.register_command(AddStaffCommand);
+    registry.register_command(AlertCommand);
+    registry.register_command(CloseCommand);
+    registry.register_command(DeleteCommand);
+    registry.register_command(EditCommand);
+    registry.register_command(ForceCloseCommand);
+    registry.register_command(HelpCommand);
+    registry.register_command(IdCommand);
+    registry.register_command(MoveCommand);
+    registry.register_command(NewThreadCommand);
+    registry.register_command(RecoverCommand);
+    registry.register_command(RemoveStaffCommand);
+    registry.register_command(ReplyCommand);
+
+    let registry = Arc::new(registry);
+
     let mut client: serenity::Client = ClientBuilder::new(config.bot.token.clone(), intents)
         .cache_settings(cache_settings)
-        .event_handler(ReadyHandler::new(&config))
+        .event_handler(ReadyHandler::new(&config, registry.clone()))
         .event_handler(GuildMessagesHandler::new(&config))
         .event_handler(TypingProxyHandler::new(&config))
         .event_handler(GuildMembersHandler::new(&config))
         .event_handler(GuildMessageReactionsHandler::new(&config))
         .event_handler(GuildModerationHandler::new(&config))
-        .event_handler(InteractionHandler::new(&config))
+        .event_handler(InteractionHandler::new(&config, registry.clone()))
         .event_handler(GuildHandler::new(&config))
         .await
         .expect("Failed to create client.");


### PR DESCRIPTION
This pull request refactors the implementation of all slash commands to use a new `RegistrableCommand` trait, improving code organization and extensibility. Each command is now represented as a struct implementing this trait, encapsulating registration and execution logic. Additionally, the PR standardizes error import ordering and updates function signatures to use boxed futures for async compatibility.

**Command trait refactoring:**

* Introduced a new `RegistrableCommand` trait and updated commands to implement this trait as structs. This change encapsulates command registration and execution logic, making it easier to add or modify commands in the future.
* Updated the `register` and `run` methods in these commands to return boxed futures (`BoxFuture`), improving async handling and trait object compatibility.

**Code consistency and correctness:**

* Standardized the order of error imports for consistency across files.
* Updated function calls and parameters to use references and clones where necessary, ensuring correct async behavior and avoiding ownership issues.

**Minor improvements:**

* Improved formatting and code clarity in several async blocks and match statements, especially in the `close` command's scheduling logic.

These changes collectively modernize the command handling architecture, making it more modular and maintainable.