### PR TITLE
feat(commands): add user context to add_staff command

### DIFF
--- a/src/commands/alert/common.rs
+++ b/src/commands/alert/common.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::db::{cancel_alert_for_staff, get_user_id_from_channel_id, set_alert_for_staff};
 use crate::errors::DatabaseError::QueryFailed;
 use crate::errors::DiscordError::ApiError;
-use crate::errors::{common, ModmailError, ModmailResult};
+use crate::errors::{ModmailError, ModmailResult, common};
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::colours::branding::GREEN;
 use serenity::all::{CommandInteraction, Context, CreateInteractionResponse, Message};

--- a/src/commands/alert/slash_command/alert.rs
+++ b/src/commands/alert/slash_command/alert.rs
@@ -4,7 +4,7 @@ use crate::commands::alert::common::{
 };
 use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::errors::{common, CommandError, ModmailError, ModmailResult};
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use serenity::all::{

--- a/src/commands/close/slash_command/close.rs
+++ b/src/commands/close/slash_command/close.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::db::{
     close_thread, delete_scheduled_closure, get_scheduled_closure, upsert_scheduled_closure,
 };
-use crate::errors::{common, CommandError, ModmailError, ModmailResult};
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;

--- a/src/commands/delete/slash_command/delete.rs
+++ b/src/commands/delete/slash_command/delete.rs
@@ -4,7 +4,7 @@ use crate::commands::delete::common::{
 };
 use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::errors::{common, MessageError, ModmailError, ModmailResult};
+use crate::errors::{MessageError, ModmailError, ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response_ephemeral;
 use crate::utils::message::message_builder::MessageBuilder;

--- a/src/commands/edit/slash_command/edit.rs
+++ b/src/commands/edit/slash_command/edit.rs
@@ -4,7 +4,7 @@ use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::{get_thread_message_by_inbox_message_id, update_message_content};
 use crate::errors::common::message_not_found;
-use crate::errors::{common, ModmailResult};
+use crate::errors::{ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::conversion::hex_string_to_int::hex_string_to_int;

--- a/src/commands/force_close/slash_command/force_close.rs
+++ b/src/commands/force_close/slash_command/force_close.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::db::threads::{is_a_ticket_channel, is_orphaned_thread_channel};
 use crate::errors::DatabaseError::QueryFailed;
 use crate::errors::ThreadError::{NotAThreadChannel, UserStillInServer};
-use crate::errors::{common, ModmailError, ModmailResult};
+use crate::errors::{ModmailError, ModmailResult, common};
 use crate::i18n::get_translated_message;
 use serenity::all::{CommandInteraction, Context, CreateCommand, ResolvedOption};
 

--- a/src/commands/new_thread/slash_command/new_thread.rs
+++ b/src/commands/new_thread/slash_command/new_thread.rs
@@ -3,7 +3,7 @@ use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::{create_thread_for_user, get_thread_channel_by_user_id, thread_exists};
 use crate::errors::{
-    common, CommandError, DatabaseError, DiscordError, ModmailError, ModmailResult,
+    CommandError, DatabaseError, DiscordError, ModmailError, ModmailResult, common,
 };
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;

--- a/src/commands/recover/slash_command/recover.rs
+++ b/src/commands/recover/slash_command/recover.rs
@@ -1,6 +1,6 @@
 use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::errors::{common, ModmailResult};
+use crate::errors::{ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::modules::message_recovery::recover_missing_messages;
 use crate::utils::command::defer_response::defer_response;

--- a/src/commands/remove_staff/slash_command/remove_staff.rs
+++ b/src/commands/remove_staff/slash_command/remove_staff.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::db::thread_exists;
 use crate::errors::CommandError::InvalidFormat;
 use crate::errors::ThreadError::NotAThreadChannel;
-use crate::errors::{common, CommandError, ModmailError, ModmailResult};
+use crate::errors::{CommandError, ModmailError, ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;

--- a/src/commands/reply/slash_command/reply.rs
+++ b/src/commands/reply/slash_command/reply.rs
@@ -2,11 +2,11 @@ use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
 use crate::db::allocate_next_message_number;
 use crate::errors::MessageError::MessageEmpty;
-use crate::errors::{common, CommandError, ModmailError, ModmailResult, ThreadError};
+use crate::errors::{CommandError, ModmailError, ModmailResult, ThreadError, common};
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
-use crate::utils::message::reply_intent::{extract_intent, ReplyIntent};
+use crate::utils::message::reply_intent::{ReplyIntent, extract_intent};
 use crate::utils::thread::fetch_thread::fetch_thread;
 use serenity::all::{
     Attachment, CommandDataOptionValue, CommandInteraction, CommandOptionType, Context,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use crate::commands::CommandRegistry;
 use crate::commands::add_staff::slash_command::add_staff::AddStaffCommand;
 use crate::commands::alert::slash_command::alert::AlertCommand;
 use crate::commands::close::slash_command::close::CloseCommand;
@@ -11,7 +12,6 @@ use crate::commands::new_thread::slash_command::new_thread::NewThreadCommand;
 use crate::commands::recover::slash_command::recover::RecoverCommand;
 use crate::commands::remove_staff::slash_command::remove_staff::RemoveStaffCommand;
 use crate::commands::reply::slash_command::reply::ReplyCommand;
-use crate::commands::CommandRegistry;
 use crate::handlers::guild_handler::GuildHandler;
 use crate::handlers::guild_interaction_handler::InteractionHandler;
 use crate::handlers::guild_message_reactions_handler::GuildMessageReactionsHandler;


### PR DESCRIPTION
This pull request primarily consists of code quality improvements, specifically reordering import statements for consistency and clarity across multiple command modules. Additionally, there are enhancements to the `add_staff` command to support user context menu interactions and improved argument handling.

**Enhancements to command functionality:**

* Added support for invoking the `add_staff` command as a user context menu command by registering it with `CommandType::User` and handling `target_id` as a fallback for `user_id` argument extraction. [[1]](diffhunk://#diff-9e6162286542587fcbe142a0702ef0c49368bbf691bb73f4b2a63fcbc05b10bdR55) [[2]](diffhunk://#diff-9e6162286542587fcbe142a0702ef0c49368bbf691bb73f4b2a63fcbc05b10bdL92-R101)

**Code quality and consistency improvements:**

* Standardized the order of imports throughout many files, placing `common` after other error types for improved readability. [[1]](diffhunk://#diff-9e6162286542587fcbe142a0702ef0c49368bbf691bb73f4b2a63fcbc05b10bdL7-R13) [[2]](diffhunk://#diff-48ffb657b271b9e4d71673510c85e70160c5565a26f56b95f1c7d32512b2b7cdL5-R5) [[3]](diffhunk://#diff-9556406bb39f8d91b40496953fbc15be7d0c973bb0d06512ccd722b8c6dc3b38L7-R7) [[4]](diffhunk://#diff-212cd7462f7654370877432450f9e3522b13e37029ff7ebaef33f23980a24130L7-R7) [[5]](diffhunk://#diff-114baaec0ad073f71964fea86d42ccdbdd26e09d1ae0d1b9cb899e38d83255b0L7-R7) [[6]](diffhunk://#diff-cdc650c6722d42a89a6b3054bbc1330a332b1e798166297f530b4371d4b816b4L7-R7) [[7]](diffhunk://#diff-d160b6f80a0eef26ae5e8f53a26d59f353b6b854f8a43376e8c8590235304dcbL7-R7) [[8]](diffhunk://#diff-177477395c32ad4a55b86259f5ef19ad7ac18d1d1bd7b3875be658647122de1eL6-R6) [[9]](diffhunk://#diff-98de14d5dd7aaaa2bd97bc354c1a1aea9069be618e50541a81227badfab54e1bL3-R3) [[10]](diffhunk://#diff-f0c89ae0be573ad8daa1672c1ea08299868bc7f775b62892ab830cbaf70bfb55L7-R7) [[11]](diffhunk://#diff-cf446e1fc5f48ce3d102fb84ee23bc3a07fc3700a5f13f4619c496a7c3a10deeL5-R9)

* Minor import order fix in `src/main.rs` to move `CommandRegistry` import to the top, aligning with convention. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR1) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL14)