### PR TITLE
feat(commands): add user context to remove_staff command

### DIFF
--- a/src/commands/remove_staff/slash_command/remove_staff.rs
+++ b/src/commands/remove_staff/slash_command/remove_staff.rs
@@ -9,8 +9,8 @@ use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::{
-    CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand,
-    CreateCommandOption, CreateInteractionResponseFollowup, ResolvedOption,
+    CommandDataOptionValue, CommandInteraction, CommandOptionType, CommandType, Context,
+    CreateCommand, CreateCommandOption, CreateInteractionResponseFollowup, ResolvedOption,
 };
 use std::collections::HashMap;
 
@@ -53,6 +53,7 @@ impl RegistrableCommand for RemoveStaffCommand {
                         CreateCommandOption::new(CommandOptionType::User, "user_id", user_id_desc)
                             .required(true),
                     ),
+                CreateCommand::new("remove_staff").kind(CommandType::User),
             ]
         })
     }
@@ -90,7 +91,15 @@ impl RegistrableCommand for RemoveStaffCommand {
                         )));
                     }
                 },
-                None => return Err(ModmailError::Command(CommandError::MissingArguments)),
+                None => {
+                    if let Some(user_id) = command.data.target_id {
+                        user_id.to_user_id()
+                    } else {
+                        return Err(ModmailError::Command(CommandError::InvalidArguments(
+                            "user_id".to_string(),
+                        )));
+                    }
+                }
             };
 
             if thread_exists(command.user.id, pool).await {


### PR DESCRIPTION
This pull request updates the `remove_staff` command to support both slash and user context menu invocations, improving its flexibility and error handling. The most important changes are:

### Command registration and invocation

* Added support for registering `remove_staff` as a user context menu command by including a new `CreateCommand` with `CommandType::User` in the command registration.
* Updated imports to include `CommandType` for the new command registration.

### Argument handling and error reporting

* Enhanced argument resolution logic to handle user context menu invocations by extracting the target user ID from `command.data.target_id` if arguments are missing, and improved error reporting for invalid or missing arguments.