### PR TITLE
fix(commands): added missing traduction for close slash command

### DIFF
--- a/src/commands/add_reminder/common.rs
+++ b/src/commands/add_reminder/common.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::db::reminders::{update_reminder_status, Reminder};
+use crate::db::reminders::{Reminder, update_reminder_status};
 use crate::utils::conversion::hex_string_to_int::hex_string_to_int;
 use crate::utils::message::message_builder::MessageBuilder;
 use chrono::Local;

--- a/src/commands/add_reminder/slash_command/add_reminder.rs
+++ b/src/commands/add_reminder/slash_command/add_reminder.rs
@@ -3,10 +3,10 @@ use crate::commands::add_reminder::common::{
 };
 use crate::commands::{BoxFuture, RegistrableCommand};
 use crate::config::Config;
-use crate::db::reminders::{insert_reminder, Reminder};
+use crate::db::reminders::{Reminder, insert_reminder};
 use crate::db::threads::get_thread_by_user_id;
 use crate::errors::{
-    common, CommandError, DatabaseError, ModmailError, ModmailResult, ThreadError,
+    CommandError, DatabaseError, ModmailError, ModmailResult, ThreadError, common,
 };
 use crate::i18n::get_translated_message;
 use crate::utils::command::defer_response::defer_response;

--- a/src/commands/add_reminder/text_command/add_reminder.rs
+++ b/src/commands/add_reminder/text_command/add_reminder.rs
@@ -2,10 +2,10 @@ use crate::commands::add_reminder::common::{
     send_register_confirmation_from_message, spawn_reminder,
 };
 use crate::config::Config;
-use crate::db::reminders::{insert_reminder, Reminder};
+use crate::db::reminders::{Reminder, insert_reminder};
 use crate::db::threads::get_thread_by_user_id;
 use crate::errors::{
-    common, CommandError, DatabaseError, ModmailError, ModmailResult, ThreadError,
+    CommandError, DatabaseError, ModmailError, ModmailResult, ThreadError, common,
 };
 use crate::utils::command::extract_reply_content::extract_reply_content;
 use chrono::{Local, NaiveTime};

--- a/src/commands/close/slash_command/close.rs
+++ b/src/commands/close/slash_command/close.rs
@@ -39,21 +39,53 @@ impl RegistrableCommand for CloseCommand {
                 None,
             )
             .await;
+            let time_before_close_desc = get_translated_message(
+                &config,
+                "slash_command.close_time_before_close_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let silent_desc = get_translated_message(
+                &config,
+                "slash_command.close_silent_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let cancel_desc = get_translated_message(
+                &config,
+                "slash_command.close_cancel_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
 
             vec![
-                CreateCommand::new("close").description(cmd_desc).add_option(
-                    CreateCommandOption::new(
-                        CommandOptionType::String, "time_before_close", "Duration before the thread is closed (e.g., 10m, 1h, 2d). Defaults the thread is closed immediately.")
-                        .required(false)
-                ).add_option(
-                    CreateCommandOption::new(
-                        CommandOptionType::Boolean, "silent", "If set, the user will not be notified when the thread is closed.")
-                        .required(false)
-                ).add_option(
-                    CreateCommandOption::new(
-                        CommandOptionType::Boolean, "cancel", "If set, cancels any scheduled closure for this thread.")
-                        .required(false)
-                )
+                CreateCommand::new("close")
+                    .description(cmd_desc)
+                    .add_option(
+                        CreateCommandOption::new(
+                            CommandOptionType::String,
+                            "time_before_close",
+                            time_before_close_desc,
+                        )
+                        .required(false),
+                    )
+                    .add_option(
+                        CreateCommandOption::new(CommandOptionType::Boolean, "silent", silent_desc)
+                            .required(false),
+                    )
+                    .add_option(
+                        CreateCommandOption::new(CommandOptionType::Boolean, "cancel", cancel_desc)
+                            .required(false),
+                    ),
             ]
         })
     }

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -638,6 +638,18 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("Close the current thread"),
     );
     dict.messages.insert(
+        "slash_command.close_time_before_close_argument".to_string(),
+        DictionaryMessage::new("The time to wait before closing the ticket (ex: 1s, 1m, 1h, 1d)"),
+    );
+    dict.messages.insert(
+        "slash_command.close_silent_argument".to_string(),
+        DictionaryMessage::new("Set to true to close the ticket without notifying the user"),
+    );
+    dict.messages.insert(
+        "slash_command.close_cancel_argument".to_string(),
+        DictionaryMessage::new("Set to true to cancel a scheduled closure"),
+    );
+    dict.messages.insert(
         "slash_command.edit_command_description".to_string(),
         DictionaryMessage::new("Edit a previously sent message"),
     );

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -657,6 +657,20 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("Fermer un ticket de support"),
     );
     dict.messages.insert(
+        "slash_command.close_time_before_close_argument".to_string(),
+        DictionaryMessage::new("Le temps avant la fermeture du ticket (ex: 1s, 1m, 1h, 1d)"),
+    );
+    dict.messages.insert(
+        "slash_command.close_silent_argument".to_string(),
+        DictionaryMessage::new(
+            "Fermer le ticket silencieusement sans envoyer de message à l'utilisateur",
+        ),
+    );
+    dict.messages.insert(
+        "slash_command.close_cancel_argument".to_string(),
+        DictionaryMessage::new("Annuler la fermeture programmée du ticket"),
+    );
+    dict.messages.insert(
         "slash_command.edit_command_description".to_string(),
         DictionaryMessage::new("Editer un message envoyé dans un ticket de support"),
     );


### PR DESCRIPTION
This pull request mainly improves the internationalization (i18n) and user experience for the `/close` slash command by providing localized descriptions for its arguments in both English and French. It also includes minor code style improvements for import ordering.

Enhancements to `/close` command argument descriptions:

* The `/close` command now retrieves localized descriptions for its arguments (`time_before_close`, `silent`, and `cancel`) using the `get_translated_message` function, ensuring users see descriptions in their preferred language.
* Added new English messages for the `/close` command arguments in `src/i18n/language/en.rs`, providing clear descriptions for each option.
* Added corresponding French translations for these argument descriptions in `src/i18n/language/fr.rs`.

Code style improvements:

* Standardized the ordering of imports in several files for consistency and readability. [[1]](diffhunk://#diff-aeb1c1044050e5bc98f764ee0553286a129bd56a425d2b9265856d317a1f2601L2-R2) [[2]](diffhunk://#diff-036ee3ce4963f3df3112d8b30cec41416b20464402da3a24970850a0f4743bbeL6-R9) [[3]](diffhunk://#diff-2fb5dea5f5102127618fd7e521c1cdd324be081edde7056252bf7b0f49289693L5-R8)