### PR TITLE
feat(commands): add remove_reminder command

### DIFF
--- a/src/commands/add_reminder/slash_command/add_reminder.rs
+++ b/src/commands/add_reminder/slash_command/add_reminder.rs
@@ -199,7 +199,7 @@ impl RegistrableCommand for AddReminderCommand {
             )
             .await;
 
-            spawn_reminder(&reminder, &ctx, &config, &pool);
+            spawn_reminder(&reminder, Some(reminder_id), &ctx, &config, &pool);
 
             Ok(())
         })

--- a/src/commands/add_reminder/text_command/add_reminder.rs
+++ b/src/commands/add_reminder/text_command/add_reminder.rs
@@ -100,7 +100,7 @@ pub async fn add_reminder(ctx: &Context, msg: &Message, config: &Config) -> Modm
 
     let _ = msg.delete(&ctx.http).await;
 
-    spawn_reminder(&reminder, &ctx, &config, &pool);
+    spawn_reminder(&reminder, Some(reminder_id), &ctx, &config, &pool);
 
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod id;
 pub mod move_thread;
 pub mod new_thread;
 pub mod recover;
+pub mod remove_reminder;
 pub mod remove_staff;
 pub mod reply;
 

--- a/src/commands/remove_reminder/mod.rs
+++ b/src/commands/remove_reminder/mod.rs
@@ -1,0 +1,2 @@
+pub mod slash_command;
+pub mod text_command;

--- a/src/commands/remove_reminder/slash_command/mod.rs
+++ b/src/commands/remove_reminder/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod remove_reminder;

--- a/src/commands/remove_reminder/slash_command/remove_reminder.rs
+++ b/src/commands/remove_reminder/slash_command/remove_reminder.rs
@@ -1,0 +1,135 @@
+use crate::commands::{BoxFuture, RegistrableCommand};
+use crate::config::Config;
+use crate::db::reminders::{get_reminder_by_id, update_reminder_status};
+use crate::errors::{CommandError, DatabaseError, ModmailError, ModmailResult, common};
+use crate::i18n::get_translated_message;
+use crate::utils::command::defer_response::defer_response;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{
+    CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand,
+    CreateCommandOption, ResolvedOption,
+};
+use std::collections::HashMap;
+
+pub struct RemoveReminderCommand;
+
+impl RegistrableCommand for RemoveReminderCommand {
+    fn name(&self) -> &'static str {
+        "remove_reminder"
+    }
+
+    fn register(&self, config: &Config) -> BoxFuture<Vec<CreateCommand>> {
+        let config = config.clone();
+        let name = self.name();
+
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.remove_reminder_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+            let id_desc = get_translated_message(
+                &config,
+                "slash_command.remove_reminder_id_argument",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+            vec![CreateCommand::new(name).description(cmd_desc).add_option(
+                CreateCommandOption::new(CommandOptionType::Number, "id", id_desc).required(true),
+            )]
+        })
+    }
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        options: &[ResolvedOption<'_>],
+        config: &Config,
+    ) -> BoxFuture<ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(common::database_connection_failed)?;
+
+            let _ = defer_response(&ctx, &command).await;
+
+            let mut reminder_id: Option<i64> = None;
+
+            for option in &command.data.options {
+                match option.name.as_str() {
+                    "id" => {
+                        if let CommandDataOptionValue::Number(val) = &option.value {
+                            reminder_id.replace(*val as i64);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            let reminder_id = match reminder_id {
+                Some(id) => id,
+                None => {
+                    return Err(ModmailError::Command(CommandError::InvalidArguments(
+                        "reminder ID".to_string(),
+                    )));
+                }
+            };
+
+            let reminder = match get_reminder_by_id(reminder_id, pool).await {
+                Ok(Some(r)) => r,
+                Ok(None) => {
+                    return Err(ModmailError::Database(DatabaseError::NotFound(
+                        "".to_string(),
+                    )));
+                }
+                Err(e) => {
+                    return Err(ModmailError::Database(DatabaseError::QueryFailed(
+                        e.to_string(),
+                    )));
+                }
+            };
+
+            match update_reminder_status(&reminder, true, pool).await {
+                Ok(_) => {
+                    let mut params = HashMap::new();
+                    params.insert("id".to_string(), reminder_id.to_string());
+
+                    let response = MessageBuilder::system_message(&ctx, &config)
+                        .translated_content(
+                            "remove_reminder.confirmation",
+                            Some(&params),
+                            None,
+                            None,
+                        )
+                        .await
+                        .to_channel(command.channel_id)
+                        .build_interaction_message_followup()
+                        .await;
+
+                    let _ = command.create_followup(&ctx.http, response).await;
+                }
+                Err(e) => {
+                    return Err(ModmailError::Database(DatabaseError::QueryFailed(
+                        e.to_string(),
+                    )));
+                }
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/src/commands/remove_reminder/text_command/mod.rs
+++ b/src/commands/remove_reminder/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod remove_reminder;

--- a/src/commands/remove_reminder/text_command/remove_reminder.rs
+++ b/src/commands/remove_reminder/text_command/remove_reminder.rs
@@ -1,0 +1,71 @@
+use crate::config::Config;
+use crate::db::reminders::{get_reminder_by_id, update_reminder_status};
+use crate::errors::{CommandError, DatabaseError, ModmailError, ModmailResult, common};
+use crate::utils::command::extract_reply_content::extract_reply_content;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{Context, Message};
+use std::collections::HashMap;
+
+pub async fn remove_reminder(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
+    let pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(common::database_connection_failed)?;
+
+    let content = match extract_reply_content(
+        &msg.content,
+        &config.command.prefix,
+        &["remove_reminder", "rr"],
+    ) {
+        Some(c) => c,
+        None => {
+            return Err(ModmailError::Command(CommandError::InvalidArguments(
+                "".to_string(),
+            )));
+        }
+    };
+
+    let reminder_id = match content.parse::<u64>() {
+        Ok(id) => id,
+        Err(_) => {
+            return Err(ModmailError::Command(CommandError::InvalidArguments(
+                "Reminder ID".to_string(),
+            )));
+        }
+    };
+
+    let reminder = match get_reminder_by_id(reminder_id as i64, pool).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return Err(ModmailError::Database(DatabaseError::NotFound(
+                "".to_string(),
+            )));
+        }
+        Err(e) => {
+            return Err(ModmailError::Database(DatabaseError::QueryFailed(
+                e.to_string(),
+            )));
+        }
+    };
+
+    match update_reminder_status(&reminder, true, pool).await {
+        Ok(_) => {
+            let mut params = HashMap::new();
+            params.insert("id".to_string(), reminder_id.to_string());
+
+            let _ = MessageBuilder::system_message(&ctx, &config)
+                .translated_content("remove_reminder.confirmation", Some(&params), None, None)
+                .await
+                .to_channel(msg.channel_id)
+                .send()
+                .await;
+        }
+        Err(e) => {
+            return Err(ModmailError::Database(DatabaseError::QueryFailed(
+                e.to_string(),
+            )));
+        }
+    }
+
+    Ok(())
+}

--- a/src/db/operations/reminders.rs
+++ b/src/db/operations/reminders.rs
@@ -74,3 +74,43 @@ pub async fn get_all_pending_reminders(
     .await?;
     Ok(rows)
 }
+
+pub async fn get_reminder_by_id(
+    reminder_id: i64,
+    pool: &sqlx::SqlitePool,
+) -> Result<Option<Reminder>, sqlx::Error> {
+    let row = sqlx::query_as!(
+        Reminder,
+        r#"
+        SELECT thread_id, user_id, channel_id, guild_id, reminder_content, trigger_time, created_at, completed
+        FROM reminders
+        WHERE id = ?
+        "#,
+        reminder_id
+    )
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+pub async fn is_reminder_active(
+    reminder_id: i64,
+    pool: &sqlx::SqlitePool,
+) -> Result<bool, sqlx::Error> {
+    let row = sqlx::query!(
+        r#"
+        SELECT completed
+        FROM reminders
+        WHERE id = ?
+        "#,
+        reminder_id
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    if let Some(record) = row {
+        Ok(!record.completed)
+    } else {
+        Ok(false)
+    }
+}

--- a/src/handlers/guild_messages_handler.rs
+++ b/src/handlers/guild_messages_handler.rs
@@ -12,6 +12,7 @@ use crate::commands::id::text_command::id::id;
 use crate::commands::move_thread::text_command::move_thread::move_thread;
 use crate::commands::new_thread::text_command::new_thread::new_thread;
 use crate::commands::recover::text_command::recover::recover;
+use crate::commands::remove_reminder::text_command::remove_reminder::remove_reminder;
 use crate::commands::remove_staff::text_command::remove_staff::remove_staff;
 use crate::commands::reply::text_command::reply::reply;
 use crate::config::Config;
@@ -72,6 +73,7 @@ impl GuildMessagesHandler {
         wrap_command!(h.commands, "id", id);
         wrap_command!(h.commands, "help", help);
         wrap_command!(h.commands, ["add_reminder", "add_rap"], add_reminder);
+        wrap_command!(h.commands, ["remove_reminder", "rr"], remove_reminder);
         h
     }
 }

--- a/src/i18n/language/en.rs
+++ b/src/i18n/language/en.rs
@@ -755,4 +755,16 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         "slash_command.add_reminder_content_argument_description".to_string(),
         DictionaryMessage::new("Optional content for the reminder"),
     );
+    dict.messages.insert(
+        "remove_reminder.confirmation".to_string(),
+        DictionaryMessage::new("Reminder **#{id}** has been removed successfully"),
+    );
+    dict.messages.insert(
+        "slash_command.remove_reminder_command_description".to_string(),
+        DictionaryMessage::new("Remove one of your reminders"),
+    );
+    dict.messages.insert(
+        "slash_command.remove_reminder_id_argument".to_string(),
+        DictionaryMessage::new("The ID of the reminder to remove"),
+    );
 }

--- a/src/i18n/language/fr.rs
+++ b/src/i18n/language/fr.rs
@@ -774,4 +774,16 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         "slash_command.add_reminder_content_argument_description".to_string(),
         DictionaryMessage::new("Le contenu du rappel (optionnel)"),
     );
+    dict.messages.insert(
+        "remove_reminder.confirmation".to_string(),
+        DictionaryMessage::new("Le rappel **#{id}** a été supprimé avec succès."),
+    );
+    dict.messages.insert(
+        "slash_command.remove_reminder_command_description".to_string(),
+        DictionaryMessage::new("Supprimer un rappel que vous avez créé."),
+    );
+    dict.messages.insert(
+        "slash_command.remove_reminder_id_argument".to_string(),
+        DictionaryMessage::new("L'ID du rappel à supprimer."),
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crate::commands::id::slash_command::id::IdCommand;
 use crate::commands::move_thread::slash_command::move_thread::MoveCommand;
 use crate::commands::new_thread::slash_command::new_thread::NewThreadCommand;
 use crate::commands::recover::slash_command::recover::RecoverCommand;
+use crate::commands::remove_reminder::slash_command::remove_reminder::RemoveReminderCommand;
 use crate::commands::remove_staff::slash_command::remove_staff::RemoveStaffCommand;
 use crate::commands::reply::slash_command::reply::ReplyCommand;
 use crate::handlers::guild_handler::GuildHandler;
@@ -82,6 +83,7 @@ async fn main() {
     registry.register_command(RemoveStaffCommand);
     registry.register_command(ReplyCommand);
     registry.register_command(AddReminderCommand);
+    registry.register_command(RemoveReminderCommand);
 
     let registry = Arc::new(registry);
 

--- a/src/modules/reminders.rs
+++ b/src/modules/reminders.rs
@@ -10,7 +10,7 @@ pub async fn load_reminders(ctx: &Context, config: &Config, pool: &sqlx::SqliteP
     });
 
     for reminder in reminders {
-        spawn_reminder(&reminder, &ctx, &config, &pool);
+        spawn_reminder(&reminder, None, &ctx, &config, &pool);
     }
     println!("All pending reminders have been scheduled.");
 }


### PR DESCRIPTION
This pull request introduces a new "remove reminder" feature, allowing users to delete reminders via both slash and text commands. It also improves the reliability of the reminder system by ensuring reminders are only sent if they're still active. The changes include updates to the command registration, database access, command handlers, and internationalization support.

**New "Remove Reminder" Feature:**

* Added new slash command (`RemoveReminderCommand`) and text command (`remove_reminder`) for removing reminders, including command registration and handler logic. Both commands validate the reminder ID, check for existence, mark the reminder as removed, and provide user feedback. [[1]](diffhunk://#diff-57b38e13dfec0acee0b89a4625f489f3e7fa609b71e8baa818f37d5138073873R1-R135) [[2]](diffhunk://#diff-5f86cf8890cdb5009fd92cdf15b1c948767f94c04f9cfea7771a6d385c5b22a8R1-R71) [[3]](diffhunk://#diff-3c3c96787eb349ba48d9c8435ef0339b281654834c84db715521ef6cc11089a1R1-R2) [[4]](diffhunk://#diff-b562ed0e527e9c3d7c58e90a39dfac431ac5dfe1f4945c7da129b46905402ff6R1) [[5]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdR21) [[6]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR14) [[7]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR86) [[8]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098R15) [[9]](diffhunk://#diff-ccc984d871abbf8edd58294bdcd631ec68ac3f33c38f657857f540ce2f88f098R76)

* Added new database access functions: `get_reminder_by_id` (to fetch a reminder by its ID) and `is_reminder_active` (to check if a reminder is still active before sending). [[1]](diffhunk://#diff-891199ed92ad29900b792fe4875efe540c154afed6ec5d9ecb53102917e7688fR77-R116) [[2]](diffhunk://#diff-aeb1c1044050e5bc98f764ee0553286a129bd56a425d2b9265856d317a1f2601L2-R2) [[3]](diffhunk://#diff-aeb1c1044050e5bc98f764ee0553286a129bd56a425d2b9265856d317a1f2601R133-R146)

**Reminder Scheduling Improvements:**

* Modified `spawn_reminder` to accept an optional `reminder_id` and check if the reminder is still active before sending, preventing removed reminders from being sent. Updated all calls to `spawn_reminder` accordingly. [[1]](diffhunk://#diff-aeb1c1044050e5bc98f764ee0553286a129bd56a425d2b9265856d317a1f2601L112-R118) [[2]](diffhunk://#diff-aeb1c1044050e5bc98f764ee0553286a129bd56a425d2b9265856d317a1f2601R133-R146) [[3]](diffhunk://#diff-036ee3ce4963f3df3112d8b30cec41416b20464402da3a24970850a0f4743bbeL202-R202) [[4]](diffhunk://#diff-2fb5dea5f5102127618fd7e521c1cdd324be081edde7056252bf7b0f49289693L103-R103) [[5]](diffhunk://#diff-1bc895b6192a5fdbed6f0c1d275921a0e6ccfea518b161a805406b7f90806232L13-R13)

**Internationalization:**

* Added English and French translations for the new remove reminder command and its confirmation messages. [[1]](diffhunk://#diff-780ad995dc362842d9f4e8d891b61d05d5ff1f20c5e0172cdc8b2982ee4d7472R758-R769) [[2]](diffhunk://#diff-22822464822d3f2a7b540e77c59eaf2359e1d07f93241aff7b5ee6d019f40932R777-R788)