### PR TITLE
refactor(messages): all bot's messages are now recorded in db

### DIFF
--- a/rustmail/src/commands/add_reminder/common.rs
+++ b/rustmail/src/commands/add_reminder/common.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::db::reminders::{Reminder, is_reminder_active, update_reminder_status};
+use crate::db::reminders::{is_reminder_active, update_reminder_status, Reminder};
 use crate::utils::conversion::hex_string_to_int::hex_string_to_int;
 use crate::utils::message::message_builder::MessageBuilder;
 use chrono::Local;
@@ -42,7 +42,7 @@ pub async fn send_register_confirmation_from_message(
             .await
             .to_channel(msg.channel_id)
             .footer(format!("{}: {}", "ID", reminder_id))
-            .send(false)
+            .send(true)
             .await;
     } else {
         let _ = MessageBuilder::system_message(&ctx, &config)
@@ -55,7 +55,7 @@ pub async fn send_register_confirmation_from_message(
             .await
             .to_channel(msg.channel_id)
             .footer(format!("{}: {}", "ID", reminder_id))
-            .send(false)
+            .send(true)
             .await;
     }
 }
@@ -177,7 +177,7 @@ pub fn spawn_reminder(
                 .to_channel(ChannelId::new(reminder.channel_id as u64))
                 .color(hex_string_to_int(&config.reminders.embed_color) as u32)
                 .mention(mentions)
-                .send(false)
+                .send(true)
                 .await;
         } else {
             let _ = MessageBuilder::system_message(&ctx, &config)
@@ -186,7 +186,7 @@ pub fn spawn_reminder(
                 .to_channel(ChannelId::new(reminder.channel_id as u64))
                 .color(hex_string_to_int(&config.reminders.embed_color) as u32)
                 .mention(mentions)
-                .send(false)
+                .send(true)
                 .await;
         }
 

--- a/rustmail/src/commands/add_staff/text_command/add_staff.rs
+++ b/rustmail/src/commands/add_staff/text_command/add_staff.rs
@@ -43,7 +43,7 @@ pub async fn add_staff(
                     .translated_content("add_staff.add_success", Some(&params), None, None)
                     .await
                     .to_channel(msg.channel_id)
-                    .send(false)
+                    .send(true)
                     .await;
 
                 Ok(())

--- a/rustmail/src/commands/alert/common.rs
+++ b/rustmail/src/commands/alert/common.rs
@@ -7,7 +7,6 @@ use crate::errors::{common, ModmailError, ModmailResult};
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::colours::branding::GREEN;
 use serenity::all::{CommandInteraction, Context, CreateInteractionResponse, Message};
-use serenity::futures::SinkExt;
 use std::collections::HashMap;
 
 pub async fn get_thread_user_id_from_msg(
@@ -183,7 +182,7 @@ pub async fn send_alert_message(
         )
         .await
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await;
 }
 

--- a/rustmail/src/commands/close/slash_command/close.rs
+++ b/rustmail/src/commands/close/slash_command/close.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::db::{
     close_thread, delete_scheduled_closure, get_scheduled_closure, upsert_scheduled_closure,
 };
-use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult};
 use crate::handlers::guild_interaction_handler::InteractionHandler;
 use crate::i18n::get_translated_message;
 use crate::utils::command::category::{
@@ -19,10 +19,10 @@ use serenity::all::{
     CommandDataOptionValue, CommandInteraction, CommandOptionType, Context, CreateCommand,
     CreateCommandOption, GuildId, ResolvedOption, UserId,
 };
+use serenity::FutureExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use serenity::FutureExt;
 use tokio::time::sleep;
 
 pub struct CloseCommand;
@@ -34,9 +34,8 @@ impl RegistrableCommand for CloseCommand {
     }
 
     fn doc<'a>(&self, config: &'a Config) -> BoxFuture<'a, String> {
-        async move {
-            get_translated_message(config, "help.close", None, None, None, None).await
-        }.boxed()
+        async move { get_translated_message(config, "help.close", None, None, None, None).await }
+            .boxed()
     }
 
     fn register(&self, config: &Config) -> BoxFuture<'_, Vec<CreateCommand>> {
@@ -304,7 +303,7 @@ impl RegistrableCommand for CloseCommand {
                                         MessageBuilder::system_message(&ctx_clone, &config_clone)
                                             .content(&config_clone.bot.close_message)
                                             .to_user(user_id_clone)
-                                            .send(false)
+                                            .send(true)
                                             .await;
                                 }
                                 let _ = channel_id.delete(&ctx_clone.http).await;
@@ -352,7 +351,7 @@ impl RegistrableCommand for CloseCommand {
                                                     )
                                                     .content(&config_clone2.bot.close_message)
                                                     .to_user(user_id_clone)
-                                                    .send(false)
+                                                    .send(true)
                                                     .await;
                                                 }
                                                 let _ = channel_id.delete(&ctx_clone2.http).await;
@@ -379,7 +378,7 @@ impl RegistrableCommand for CloseCommand {
                 let _ = MessageBuilder::system_message(&ctx, &config)
                     .content(&config.bot.close_message)
                     .to_user(user_id)
-                    .send(false)
+                    .send(true)
                     .await;
             } else if !user_still_member {
                 let mut params = HashMap::new();

--- a/rustmail/src/commands/close/text_command/close.rs
+++ b/rustmail/src/commands/close/text_command/close.rs
@@ -91,7 +91,7 @@ pub async fn close(
                 )
                 .await
                 .to_channel(msg.channel_id)
-                .send(false)
+                .send(true)
                 .await;
         } else {
             let _ = MessageBuilder::system_message(&ctx, config)
@@ -103,7 +103,7 @@ pub async fn close(
                 )
                 .await
                 .to_channel(msg.channel_id)
-                .send(false)
+                .send(true)
                 .await;
         }
         return Ok(());
@@ -126,7 +126,7 @@ pub async fn close(
                     )
                     .await
                     .to_channel(msg.channel_id)
-                    .send(false)
+                    .send(true)
                     .await;
                 return Ok(());
             }
@@ -157,7 +157,7 @@ pub async fn close(
                 )
                 .await
                 .to_channel(msg.channel_id)
-                .send(false)
+                .send(true)
                 .await;
         } else {
             let _ = MessageBuilder::system_message(&ctx, config)
@@ -169,7 +169,7 @@ pub async fn close(
                 )
                 .await
                 .to_channel(msg.channel_id)
-                .send(false)
+                .send(true)
                 .await;
         };
 
@@ -263,7 +263,7 @@ pub async fn close(
                             let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
                                 .content(&config_clone.bot.close_message)
                                 .to_user(user_id_clone)
-                                .send(false)
+                                .send(true)
                                 .await;
                         }
                         let _ = channel_id.delete(&ctx_clone.http).await;
@@ -305,7 +305,7 @@ pub async fn close(
                                             )
                                             .content(&config_clone2.bot.close_message)
                                             .to_user(user_id_clone)
-                                            .send(false)
+                                            .send(true)
                                             .await;
                                         }
                                         let _ = channel_id.delete(&ctx_clone2.http).await;
@@ -331,7 +331,7 @@ pub async fn close(
         let _ = MessageBuilder::system_message(&ctx, config)
             .content(&config.bot.close_message)
             .to_user(user_id)
-            .send(false)
+            .send(true)
             .await;
     } else if !user_still_member {
         let mut params = HashMap::new();
@@ -346,7 +346,7 @@ pub async fn close(
             )
             .await
             .to_channel(msg.channel_id)
-            .send(false)
+            .send(true)
             .await;
     }
 

--- a/rustmail/src/commands/delete/common.rs
+++ b/rustmail/src/commands/delete/common.rs
@@ -5,7 +5,7 @@ use crate::db::{
     delete_message, get_message_ids_by_number, get_thread_by_channel_id,
     get_user_id_from_channel_id, update_message_numbers_after_deletion,
 };
-use crate::errors::{CommandError, ModmailError, ModmailResult, common};
+use crate::errors::{common, CommandError, ModmailError, ModmailResult};
 use crate::utils::message::message_builder::MessageBuilder;
 use serenity::all::{ChannelId, Context, Message, MessageId, UserId};
 use std::collections::HashMap;
@@ -166,6 +166,6 @@ pub async fn send_delete_message(
         )
         .await
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await;
 }

--- a/rustmail/src/commands/edit/text_command/edit.rs
+++ b/rustmail/src/commands/edit/text_command/edit.rs
@@ -118,7 +118,7 @@ pub async fn edit(
                     .await
                     .color(hex_string_to_int(&config.thread.system_message_color) as u32)
                     .to_channel(msg.channel_id)
-                    .send(false)
+                    .send(true)
                     .await;
             };
 
@@ -154,7 +154,7 @@ pub async fn edit(
                     )
                     .await
                     .to_channel(msg.channel_id)
-                    .send(false)
+                    .send(true)
                     .await;
             }
 

--- a/rustmail/src/commands/help/text_command/help.rs
+++ b/rustmail/src/commands/help/text_command/help.rs
@@ -22,7 +22,7 @@ pub async fn help(
     MessageBuilder::system_message(&ctx, config)
         .content(docs_message)
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await?;
 
     Ok(())

--- a/rustmail/src/commands/id/text_command/id.rs
+++ b/rustmail/src/commands/id/text_command/id.rs
@@ -37,7 +37,7 @@ pub async fn id(
             .translated_content("id.show_id", Some(&params), None, None)
             .await
             .to_channel(msg.channel_id)
-            .send(false)
+            .send(true)
             .await?;
 
         Ok(())

--- a/rustmail/src/commands/logs/common.rs
+++ b/rustmail/src/commands/logs/common.rs
@@ -101,7 +101,7 @@ pub async fn get_response(
             .content(content)
             .components(components)
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await
     }
 }

--- a/rustmail/src/commands/move_thread/common.rs
+++ b/rustmail/src/commands/move_thread/common.rs
@@ -89,7 +89,7 @@ pub async fn send_success_message(
     let _ = MessageBuilder::system_message(ctx, config)
         .content(confirmation_msg)
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await;
 
     let _ = msg.delete(&ctx.http).await;

--- a/rustmail/src/commands/new_thread/common.rs
+++ b/rustmail/src/commands/new_thread/common.rs
@@ -60,7 +60,7 @@ pub async fn send_welcome_message(
         )
         .await
         .to_channel(channel.id)
-        .send(false)
+        .send(true)
         .await;
 
     let _ = MessageBuilder::system_message(ctx, config)
@@ -81,7 +81,7 @@ pub async fn send_dm_to_user(ctx: &Context, user: &User, config: &Config) -> Mod
         .translated_content("new_thread.dm_notification", None, Some(user.id), None)
         .await
         .to_user(user.id)
-        .send(false)
+        .send(true)
         .await;
 
     Ok(())
@@ -103,7 +103,7 @@ pub async fn send_error_message(
         )
         .await
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await;
 }
 
@@ -135,6 +135,6 @@ pub async fn send_success_message(
         )
         .await
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await;
 }

--- a/rustmail/src/commands/recover/text_command/recover.rs
+++ b/rustmail/src/commands/recover/text_command/recover.rs
@@ -35,7 +35,7 @@ pub async fn recover(
     let _ = MessageBuilder::system_message(&ctx, config)
         .content(confirmation_message)
         .to_channel(msg.channel_id)
-        .send(false)
+        .send(true)
         .await;
 
     let ctx_clone = ctx.clone();
@@ -67,7 +67,7 @@ pub async fn recover(
         let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
             .content(summary_message)
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await;
     });
 

--- a/rustmail/src/commands/remove_reminder/text_command/remove_reminder.rs
+++ b/rustmail/src/commands/remove_reminder/text_command/remove_reminder.rs
@@ -61,7 +61,7 @@ pub async fn remove_reminder(
                 .translated_content("remove_reminder.confirmation", Some(&params), None, None)
                 .await
                 .to_channel(msg.channel_id)
-                .send(false)
+                .send(true)
                 .await;
         }
         Err(e) => {

--- a/rustmail/src/commands/remove_staff/text_command/remove_staff.rs
+++ b/rustmail/src/commands/remove_staff/text_command/remove_staff.rs
@@ -42,7 +42,7 @@ pub async fn remove_staff(
                     .translated_content("add_staff.remove_success", Some(&params), None, None)
                     .await
                     .to_channel(msg.channel_id)
-                    .send(false)
+                    .send(true)
                     .await;
 
                 Ok(())

--- a/rustmail/src/commands/reply/text_command/reply.rs
+++ b/rustmail/src/commands/reply/text_command/reply.rs
@@ -91,7 +91,7 @@ pub async fn reply(
             )
             .await
             .to_channel(msg.channel_id)
-            .send(false)
+            .send(true)
             .await;
     }
 

--- a/rustmail/src/handlers/guild_members_handler.rs
+++ b/rustmail/src/handlers/guild_members_handler.rs
@@ -96,7 +96,7 @@ impl EventHandler for GuildMembersHandler {
             .await
             .to_channel(channel_id)
             .components(close_buttons)
-            .send(false)
+            .send(true)
             .await;
 
         if let Err(e) = update_thread_user_left(&thread.channel_id, pool).await {

--- a/rustmail/src/handlers/guild_messages_handler.rs
+++ b/rustmail/src/handlers/guild_messages_handler.rs
@@ -290,7 +290,7 @@ impl EventHandler for GuildMessagesHandler {
                 .to_channel(ChannelId::new(
                     thread.channel_id.parse::<u64>().unwrap_or(0),
                 ))
-                .send(false)
+                .send(true)
                 .await;
         }
 
@@ -418,7 +418,7 @@ impl EventHandler for GuildMessagesHandler {
                             )
                             .await
                             .to_channel(channel_id_parse)
-                            .send(false)
+                            .send(true)
                             .await;
                     }
 

--- a/rustmail/src/handlers/guild_moderation_handler.rs
+++ b/rustmail/src/handlers/guild_moderation_handler.rs
@@ -256,7 +256,7 @@ async fn manage_creating_ticket_via_opening_thread(
         .await
         .components(res_button)
         .to_channel(channel_id_inner)
-        .send(false)
+        .send(true)
         .await;
 }
 
@@ -299,7 +299,7 @@ impl EventHandler for GuildModerationHandler {
         let _ = MessageBuilder::user_message(&ctx, &self.config, user.id, user.name)
             .to_channel(ChannelId::new(logs_channel_id))
             .content(format_audit_log(&entry))
-            .send(false)
+            .send(true)
             .await;
     }
 }

--- a/rustmail/src/modules/message_recovery.rs
+++ b/rustmail/src/modules/message_recovery.rs
@@ -193,7 +193,7 @@ async fn recover_messages_for_thread(
             )
             .await
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await;
     }
 

--- a/rustmail/src/modules/scheduled_closures.rs
+++ b/rustmail/src/modules/scheduled_closures.rs
@@ -6,7 +6,7 @@ use crate::db::{
 use crate::utils::message::message_builder::MessageBuilder;
 use chrono::Utc;
 use serenity::all::{ChannelId, Context, UserId};
-use tokio::time::{Duration, sleep};
+use tokio::time::{sleep, Duration};
 
 fn schedule_one(ctx: &Context, config: &Config, thread_id: String, close_at: i64) {
     let now = Utc::now().timestamp();
@@ -40,7 +40,7 @@ fn schedule_one(ctx: &Context, config: &Config, thread_id: String, close_at: i64
                             let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
                                 .content(&config_clone.bot.close_message)
                                 .to_user(user_id)
-                                .send(false)
+                                .send(true)
                                 .await;
                         }
                         let _ = channel_id.delete(&ctx_clone.http).await;
@@ -90,7 +90,7 @@ pub async fn hydrate_scheduled_closures(ctx: &Context, config: &Config) {
                     let _ = MessageBuilder::system_message(ctx, config)
                         .content(&config.bot.close_message)
                         .to_user(user_id)
-                        .send(false)
+                        .send(true)
                         .await;
                 }
                 let _ = channel_id.delete(&ctx.http).await;

--- a/rustmail/src/modules/threads.rs
+++ b/rustmail/src/modules/threads.rs
@@ -458,14 +458,14 @@ pub async fn handle_thread_modal_interaction(
                 )
                 .await
                 .to_channel(interaction.channel_id)
-                .send(false)
+                .send(true)
                 .await;
 
             let _ = MessageBuilder::system_message(ctx, config)
                 .translated_content("new_thread.dm_notification", None, Some(user_id), None)
                 .await
                 .to_user(user_id)
-                .send(false)
+                .send(true)
                 .await;
 
             let mut params = HashMap::new();

--- a/rustmail/src/utils/message/message_builder.rs
+++ b/rustmail/src/utils/message/message_builder.rs
@@ -481,7 +481,7 @@ impl<'a> MessageBuilder<'a> {
         };
 
         if to_be_recorded {
-            match insert_staff_message(
+            let _ = insert_staff_message(
                 &self.ctx,
                 &message,
                 dm_message_id,
@@ -492,14 +492,7 @@ impl<'a> MessageBuilder<'a> {
                 self.config,
                 None,
             )
-            .await
-            {
-                Ok(_) => (),
-                Err(e) => {
-                    println!("Failed to record sent message: {}", e);
-                    return Err(ModmailError::from(e));
-                }
-            };
+            .await;
         }
 
         Ok(message)
@@ -607,7 +600,7 @@ impl<'a> MessageBuilder<'a> {
     }
 
     pub async fn send_and_forget(self) {
-        if let Err(e) = self.send(false).await {
+        if let Err(e) = self.send(true).await {
             eprintln!("Failed to send message: {}", e);
         }
     }
@@ -651,7 +644,7 @@ impl<'a> MessageBuilder<'a> {
         Self::system_message(ctx, config)
             .content(content)
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await
     }
 
@@ -664,7 +657,7 @@ impl<'a> MessageBuilder<'a> {
         Self::system_message(ctx, config)
             .content(content)
             .to_user(user_id)
-            .send(false)
+            .send(true)
             .await
     }
 
@@ -677,7 +670,7 @@ impl<'a> MessageBuilder<'a> {
         Self::system_message(ctx, config)
             .content(content)
             .reply_to(message)
-            .send(false)
+            .send(true)
             .await
     }
 }
@@ -794,7 +787,7 @@ impl<'a> StaffReply<'a> {
                 .color(hex_string_to_int(&self.config.thread.staff_message_color) as u32)
                 .to_user(dm_user);
 
-            match dm_builder.send(false).await {
+            match dm_builder.send(true).await {
                 Ok(m) => Some(m),
                 Err(e) => {
                     eprintln!("Failed to send DM to user: {}", e);
@@ -838,7 +831,7 @@ impl<'a> StaffReply<'a> {
             .add_attachments(self.attachments.clone())
             .to_channel(thread_channel);
 
-        let thread_msg = thread_builder.send(false).await?;
+        let thread_msg = thread_builder.send(true).await?;
 
         let dm_msg_opt: Option<Message> = self.build_and_send_message(top_role_name).await;
 
@@ -990,7 +983,7 @@ impl<'a> UserIncoming<'a> {
         .content(self.content)
         .add_attachments(self.attachments)
         .to_channel(thread_channel);
-        let sent = builder.send(false).await?;
+        let sent = builder.send(true).await?;
         if let Err(e) = insert_user_message_with_ids(
             self.dm_msg,
             &sent,

--- a/rustmail/src/utils/thread/send_to_thread.rs
+++ b/rustmail/src/utils/thread/send_to_thread.rs
@@ -89,7 +89,7 @@ pub async fn send_to_thread(
             .translated_content("user.left_server", Some(&params), Some(msg.author.id), None)
             .await
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await;
     }
 
@@ -107,7 +107,7 @@ pub async fn send_to_thread(
             )
             .await
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await;
     }
 
@@ -171,7 +171,7 @@ pub async fn send_to_thread(
             .content(full_content)
             .mention(mentions)
             .to_channel(channel_id)
-            .send(false)
+            .send(true)
             .await;
 
         for staff_id in &alerts {


### PR DESCRIPTION
Enable db record in message builder send's method.