### PR TITLE
feat(commands): add take command

### DIFF
--- a/rustmail/src/bot.rs
+++ b/rustmail/src/bot.rs
@@ -14,6 +14,7 @@ use crate::commands::recover::slash_command::recover::RecoverCommand;
 use crate::commands::remove_reminder::slash_command::remove_reminder::RemoveReminderCommand;
 use crate::commands::remove_staff::slash_command::remove_staff::RemoveStaffCommand;
 use crate::commands::reply::slash_command::reply::ReplyCommand;
+use crate::commands::take::slash_command::take::TakeCommand;
 use crate::commands::CommandRegistry;
 use crate::config::load_config;
 use crate::errors::types::ConfigError;
@@ -160,6 +161,7 @@ pub async fn run_bot(
     registry.register_command(AddReminderCommand);
     registry.register_command(RemoveReminderCommand);
     registry.register_command(LogsCommand);
+    registry.register_command(TakeCommand);
 
     let registry = Arc::new(registry);
 

--- a/rustmail/src/commands/mod.rs
+++ b/rustmail/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod recover;
 pub mod remove_reminder;
 pub mod remove_staff;
 pub mod reply;
+pub mod take;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 

--- a/rustmail/src/commands/take/mod.rs
+++ b/rustmail/src/commands/take/mod.rs
@@ -1,0 +1,2 @@
+pub mod slash_command;
+pub mod text_command;

--- a/rustmail/src/commands/take/slash_command/mod.rs
+++ b/rustmail/src/commands/take/slash_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod take;

--- a/rustmail/src/commands/take/slash_command/take.rs
+++ b/rustmail/src/commands/take/slash_command/take.rs
@@ -1,0 +1,118 @@
+use crate::commands::{BoxFuture, RegistrableCommand};
+use crate::config::Config;
+use crate::db::threads::is_a_ticket_channel;
+use crate::db::get_thread_by_channel_id;
+use crate::errors::common::{database_connection_failed, thread_not_found};
+use crate::errors::ThreadError::NotAThreadChannel;
+use crate::errors::{CommandError, ModmailError, ModmailResult};
+use crate::handlers::guild_interaction_handler::InteractionHandler;
+use crate::i18n::get_translated_message;
+use crate::utils::command::defer_response::defer_response;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{
+    ChannelId, CommandInteraction, Context, CreateCommand, EditChannel, ResolvedOption,
+};
+use serenity::FutureExt;
+use std::sync::Arc;
+
+pub struct TakeCommand;
+
+#[async_trait::async_trait]
+impl RegistrableCommand for TakeCommand {
+    fn name(&self) -> &'static str {
+        "take"
+    }
+
+    fn doc<'a>(&self, config: &'a Config) -> BoxFuture<'a, String> {
+        async move { get_translated_message(config, "help.take", None, None, None, None).await }
+            .boxed()
+    }
+
+    fn register(&self, config: &Config) -> BoxFuture<'_, Vec<CreateCommand>> {
+        let config = config.clone();
+
+        Box::pin(async move {
+            let cmd_desc = get_translated_message(
+                &config,
+                "slash_command.help_command_description",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await;
+
+            vec![CreateCommand::new(self.name()).description(cmd_desc)]
+        })
+    }
+
+    fn run(
+        &self,
+        ctx: &Context,
+        command: &CommandInteraction,
+        _options: &[ResolvedOption<'_>],
+        config: &Config,
+        _handler: Arc<InteractionHandler>,
+    ) -> BoxFuture<'_, ModmailResult<()>> {
+        let ctx = ctx.clone();
+        let command = command.clone();
+        let config = config.clone();
+
+        Box::pin(async move {
+            let db_pool = config
+                .db_pool
+                .as_ref()
+                .ok_or_else(database_connection_failed)?;
+
+            defer_response(&ctx, &command).await?;
+
+            if is_a_ticket_channel(command.channel_id, &db_pool).await {
+                let thread = match get_thread_by_channel_id(
+                    &command.channel_id.to_string(),
+                    db_pool,
+                )
+                .await
+                {
+                    Some(thread) => thread,
+                    None => return Err(thread_not_found()),
+                };
+
+                let parse_thread_id = thread.channel_id.parse::<u64>().unwrap_or(0);
+
+                let thread_id = ChannelId::new(parse_thread_id);
+
+                let thread_name = thread_id
+                    .name(&ctx)
+                    .await
+                    .unwrap_or_else(|_| "Unknown".to_string());
+
+                if thread_name == format!("🔵-{}", command.user.name) {
+                    return Err(ModmailError::Command(CommandError::TicketAlreadyTaken));
+                }
+
+                let _ = thread_id
+                    .edit(
+                        &ctx.http,
+                        EditChannel::new().name(format!("🔵-{}", command.user.name)),
+                    )
+                    .await;
+
+                let mut params = std::collections::HashMap::new();
+                params.insert("staff".to_string(), format!("<@{}>", command.user.id));
+
+                let response = MessageBuilder::system_message(&ctx, &config)
+                    .translated_content("take.confirmation", Some(&params), None, None)
+                    .await
+                    .to_channel(command.channel_id)
+                    .build_interaction_message_followup()
+                    .await;
+
+                let _ = command.create_followup(ctx.clone(), response).await;
+
+                Ok(())
+            } else {
+                Err(ModmailError::Thread(NotAThreadChannel))
+            }
+        })
+    }
+}

--- a/rustmail/src/commands/take/text_command/mod.rs
+++ b/rustmail/src/commands/take/text_command/mod.rs
@@ -1,0 +1,1 @@
+pub mod take;

--- a/rustmail/src/commands/take/text_command/take.rs
+++ b/rustmail/src/commands/take/text_command/take.rs
@@ -1,0 +1,64 @@
+use crate::config::Config;
+use crate::db::get_thread_by_channel_id;
+use crate::db::threads::is_a_ticket_channel;
+use crate::errors::common::{database_connection_failed, thread_not_found};
+use crate::errors::ThreadError::NotAThreadChannel;
+use crate::errors::{CommandError, ModmailError, ModmailResult};
+use crate::handlers::guild_messages_handler::GuildMessagesHandler;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{ChannelId, Context, Message};
+use serenity::builder::EditChannel;
+use std::sync::Arc;
+
+pub async fn take(
+    ctx: Context,
+    msg: Message,
+    config: &Config,
+    _handler: Arc<GuildMessagesHandler>,
+) -> ModmailResult<()> {
+    let db_pool = config
+        .db_pool
+        .as_ref()
+        .ok_or_else(database_connection_failed)?;
+
+    if is_a_ticket_channel(msg.channel_id, &db_pool).await {
+        let thread = match get_thread_by_channel_id(&msg.channel_id.to_string(), db_pool).await {
+            Some(thread) => thread,
+            None => return Err(thread_not_found()),
+        };
+
+        let parse_thread_id = thread.channel_id.parse::<u64>().unwrap_or(0);
+
+        let thread_id = ChannelId::new(parse_thread_id);
+
+        let thread_name = thread_id
+            .name(&ctx)
+            .await
+            .unwrap_or_else(|_| "Unknown".to_string());
+
+        if thread_name == format!("🔵-{}", msg.author.name) {
+            return Err(ModmailError::Command(CommandError::TicketAlreadyTaken));
+        }
+
+        let _ = thread_id
+            .edit(
+                &ctx.http,
+                EditChannel::new().name(format!("🔵-{}", msg.author.name)),
+            )
+            .await;
+
+        let mut params = std::collections::HashMap::new();
+        params.insert("staff".to_string(), format!("<@{}>", msg.author.id));
+
+        let _ = MessageBuilder::system_message(&ctx, config)
+            .translated_content("take.confirmation", Some(&params), None, None)
+            .await
+            .to_channel(msg.channel_id)
+            .send(true)
+            .await?;
+
+        Ok(())
+    } else {
+        Err(ModmailError::Thread(NotAThreadChannel))
+    }
+}

--- a/rustmail/src/errors/dictionary.rs
+++ b/rustmail/src/errors/dictionary.rs
@@ -247,6 +247,7 @@ impl DictionaryManager {
                 CommandError::NotInThread() => ("command.not_in_thread".to_string(), None),
                 CommandError::AlertDoesNotExist => ("alert.alert_not_found".to_string(), None),
                 CommandError::InvalidReminderFormat => ("add_reminder.helper".to_string(), None),
+                CommandError::TicketAlreadyTaken => ("take.ticket_already_taken".to_string(), None),
                 _ => ("command.invalid_format".to_string(), None),
             },
             ModmailError::Thread(thread_err) => match thread_err {

--- a/rustmail/src/errors/types.rs
+++ b/rustmail/src/errors/types.rs
@@ -79,6 +79,7 @@ pub enum CommandError {
     ReminderAlreadyExists,
     AlertDoesNotExist,
     InvalidReminderFormat,
+    TicketAlreadyTaken,
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +235,7 @@ impl fmt::Display for CommandError {
             CommandError::ReminderAlreadyExists => write!(f, "A reminder already exists"),
             CommandError::AlertDoesNotExist => write!(f, "Alert does not exist"),
             CommandError::InvalidReminderFormat => write!(f, "Invalid reminder format"),
+            CommandError::TicketAlreadyTaken => write!(f, "Ticket already taken"),
         }
     }
 }

--- a/rustmail/src/handlers/guild_messages_handler.rs
+++ b/rustmail/src/handlers/guild_messages_handler.rs
@@ -16,6 +16,7 @@ use crate::commands::recover::text_command::recover::recover;
 use crate::commands::remove_reminder::text_command::remove_reminder::remove_reminder;
 use crate::commands::remove_staff::text_command::remove_staff::remove_staff;
 use crate::commands::reply::text_command::reply::reply;
+use crate::commands::take::text_command::take::take;
 use crate::commands::CommandRegistry;
 use crate::config::Config;
 use crate::db::messages::get_thread_message_by_dm_message_id;
@@ -100,6 +101,7 @@ impl GuildMessagesHandler {
         wrap_command!(lock, ["remind", "rem"], add_reminder);
         wrap_command!(lock, ["unremind", "urem"], remove_reminder);
         wrap_command!(lock, "logs", logs);
+        wrap_command!(lock, "take", take);
 
         drop(lock);
         h

--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -874,9 +874,25 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("## Commands:\n\n**All commands** are also available as **__slash commands__** with the **__same name__**.\n\n"),
     );
     dict.messages.insert(
+        "help.take".to_string(),
+        DictionaryMessage::new("Allows you to take ownership of a ticket by replacing its name with yours. To take a ticket, use `!take` in the ticket."),
+    );
+    dict.messages.insert(
         "add_reminder.helper".to_string(),
         DictionaryMessage::new(
             "Incorrect format. Use : `{prefix}remind or {prefix}rem <HH:MM> [content]`",
         ),
+    );
+    dict.messages.insert(
+        "take.ticket_already_taken".to_string(),
+        DictionaryMessage::new("You have already taken this ticket."),
+    );
+    dict.messages.insert(
+        "take.confirmation".to_string(),
+        DictionaryMessage::new("The ticket is now taken by {staff}."),
+    );
+    dict.messages.insert(
+        "slash_command.help_command_description".to_string(),
+        DictionaryMessage::new("Take ownership of the current ticket."),
     );
 }

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -898,7 +898,23 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("## Commandes :\n\n**Toutes les commandes** disponibles sont également utilisables via des **__commandes slash__** portant le __même nom__.\n\n"),
     );
     dict.messages.insert(
+        "help.take".to_string(),
+        DictionaryMessage::new("Permet de prendre en charge un ticket en remplaçant le nom de celui-ci par le vôtre. Pour prendre en charge un ticket, faites `!take` dans le ticket."),
+    );
+    dict.messages.insert(
         "add_reminder.helper".to_string(),
         DictionaryMessage::new("Format incorrect. Utilisation : `{prefix}remind ou {prefix}rem <HH:MM> [contenu du rappel]`"),
+    );
+    dict.messages.insert(
+        "take.ticket_already_taken".to_string(),
+        DictionaryMessage::new("Vous avez déjà pris en charge ce ticket."),
+    );
+    dict.messages.insert(
+        "take.confirmation".to_string(),
+        DictionaryMessage::new("Le ticket est maintenant pris en charge par {staff}."),
+    );
+    dict.messages.insert(
+        "slash_command.help_command_description".to_string(),
+        DictionaryMessage::new("Prendre en charge le ticket actuel"),
     );
 }


### PR DESCRIPTION
This pull request introduces a new "take" command to the bot, allowing staff members to claim ownership of a ticket by renaming the ticket channel after themselves. The implementation includes both slash and text command variants, updates error handling for already-taken tickets, and adds internationalized help and error messages in English and French.

**New "Take" Command Implementation:**

- Added a new `TakeCommand` with both slash (`/take`) and text (`!take`) command support, enabling staff to take ownership of a ticket. The command renames the ticket channel and sends a confirmation message.

**Error Handling and Messaging:**

- Introduced a new error variant `TicketAlreadyTaken` in `CommandError` to handle cases where a user tries to take a ticket they've already claimed. Updated error dictionary and display logic accordingly.
- Added new internationalized messages for help, confirmation, and error states related to the take command in both English and French.