### PR TITLE
refactor(commands): add 'command' argument to help command

### DIFF
--- a/rustmail/src/commands/help/common.rs
+++ b/rustmail/src/commands/help/common.rs
@@ -1,0 +1,93 @@
+use crate::commands::CommandRegistry;
+use crate::config::Config;
+use crate::errors::{CommandError, ModmailError, ModmailResult};
+use crate::i18n::get_translated_message;
+use crate::utils::message::message_builder::MessageBuilder;
+use serenity::all::{CommandInteraction, Context, Message};
+use std::sync::Arc;
+
+pub async fn display_commands_list(
+    ctx: &Context,
+    config: &Config,
+    registry: Arc<CommandRegistry>,
+    msg: Option<&Message>,
+    command: Option<&CommandInteraction>,
+) -> ModmailResult<()> {
+    let mut docs_message = String::new();
+
+    let welcome_msg = get_translated_message(&config, "help.message", None, None, None, None).await;
+    docs_message.push_str(&welcome_msg);
+
+    for (name, _) in &registry.commands {
+        docs_message.push_str(&format!("- **{}**\n", name))
+    }
+
+    if let Some(msg) = msg {
+        let _ = MessageBuilder::system_message(&ctx, config)
+            .content(docs_message)
+            .to_channel(msg.channel_id)
+            .send(true)
+            .await;
+
+        return Ok(());
+    }
+
+    if let Some(command) = command {
+        let response = MessageBuilder::system_message(&ctx, config)
+            .content(docs_message)
+            .to_channel(command.channel_id)
+            .build_interaction_message_followup()
+            .await;
+
+        command.create_followup(&ctx.http, response).await?;
+
+        return Ok(());
+    }
+
+    println!("No valid message or command interaction provided.");
+    Ok(())
+}
+
+pub async fn display_command_help(
+    ctx: &Context,
+    config: &Config,
+    registry: Arc<CommandRegistry>,
+    msg: Option<&Message>,
+    command: Option<&CommandInteraction>,
+    command_name: &str,
+) -> ModmailResult<()> {
+    if let Some(cmd) = registry.commands.get(command_name) {
+        let command_doc = cmd.doc(config).await;
+        let mut docs_message = String::new();
+        docs_message.push_str(&format!("**{}**\n\n", command_name));
+        docs_message.push_str(&command_doc);
+
+        if let Some(msg) = msg {
+            let _ = MessageBuilder::system_message(&ctx, config)
+                .content(docs_message)
+                .to_channel(msg.channel_id)
+                .send(true)
+                .await;
+
+            return Ok(());
+        }
+
+        if let Some(command) = command {
+            let response = MessageBuilder::system_message(&ctx, config)
+                .content(docs_message)
+                .to_channel(command.channel_id)
+                .build_interaction_message_followup()
+                .await;
+
+            command.create_followup(&ctx.http, response).await?;
+            return Ok(());
+        }
+
+        println!("No valid message or command interaction provided.");
+        Ok(())
+    } else {
+        Err(ModmailError::Command(CommandError::UnknownCommand(
+            format!("{}", command_name),
+        )))
+    }
+}

--- a/rustmail/src/commands/help/mod.rs
+++ b/rustmail/src/commands/help/mod.rs
@@ -1,2 +1,3 @@
+pub mod common;
 pub mod slash_command;
 pub mod text_command;

--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -835,7 +835,7 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "help.help".to_string(),
-        DictionaryMessage::new("Displays a list of all available commands with a short description. To view the help message, use `!help`."),
+        DictionaryMessage::new("Displays a list of all available commands with a short description. To view the help message, use `!help`. If you want help with a specific command, type `!help <command_name>`."),
     );
     dict.messages.insert(
         "help.id".to_string(),
@@ -871,7 +871,7 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "help.message".to_string(),
-        DictionaryMessage::new("## Commands:\n\n**All commands** are also available as **__slash commands__** with the **__same name__**.\n\n"),
+        DictionaryMessage::new("## Commands:\n\n**All commands** are also available as **__slash commands__** with the **__same name__**.\n\nIf you want help with a specific command, type `!help <command_name>`.\n\n"),
     );
     dict.messages.insert(
         "help.take".to_string(),
@@ -921,5 +921,9 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "release.confirmation".to_string(),
         DictionaryMessage::new("The ticket has been released by {staff}."),
+    );
+    dict.messages.insert(
+        "slash_command.help_command_argument_desc".to_string(),
+        DictionaryMessage::new("The command to get help with"),
     );
 }

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -859,7 +859,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "help.help".to_string(),
-        DictionaryMessage::new("Affiche une liste de toutes les commandes disponibles avec une brève description. Pour afficher le message d'aide, faites `!help`."),
+        DictionaryMessage::new("Affiche une liste de toutes les commandes disponibles avec une brève description. Pour afficher le message d'aide, faites `!help`. Si vous souhaitez obtenir de l'aide sur une commande spécifique, faites `!help <nom_de_la_commande>`."),
     );
     dict.messages.insert(
         "help.id".to_string(),
@@ -895,7 +895,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "help.message".to_string(),
-        DictionaryMessage::new("## Commandes :\n\n**Toutes les commandes** disponibles sont également utilisables via des **__commandes slash__** portant le __même nom__.\n\n"),
+        DictionaryMessage::new("## Commandes :\n\n**Toutes les commandes** disponibles sont également utilisables via des **__commandes slash__** portant le __même nom__.\n\nSi vous souhaitez obtenir de l'aide sur une commande spécifique, faites `!help <nom_de_la_commande>`.\n\n")
     );
     dict.messages.insert(
         "help.take".to_string(),
@@ -936,5 +936,9 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "release.confirmation".to_string(),
         DictionaryMessage::new("Le ticket n'est plus pris en charge par {staff}."),
+    );
+    dict.messages.insert(
+        "slash_command.help_command_argument_desc".to_string(),
+        DictionaryMessage::new("Le nom de la commande pour laquelle vous souhaitez de l'aide"),
     );
 }


### PR DESCRIPTION
To list all commands, use !help.
If you want help with a specific command, simply use !help <command_name>.