### PR TITLE
fix(auth): fix authentification issue when user has no avatar

### DIFF
--- a/migrations/20251124000000_allow_null_avatar_hash.sql
+++ b/migrations/20251124000000_allow_null_avatar_hash.sql
@@ -1,0 +1,19 @@
+-- Allow NULL in avatar_hash column for users without Discord avatars
+-- SQLite doesn't support ALTER COLUMN, so we need to recreate the table
+CREATE TABLE IF NOT EXISTS sessions_panel_new (
+    session_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT,
+    expires_at INTEGER NOT NULL,
+    avatar_hash TEXT
+);
+
+-- Copy existing data
+INSERT INTO sessions_panel_new (session_id, user_id, access_token, refresh_token, expires_at, avatar_hash)
+SELECT session_id, user_id, access_token, refresh_token, expires_at, avatar_hash
+FROM sessions_panel;
+
+-- Drop old table and rename new one
+DROP TABLE sessions_panel;
+ALTER TABLE sessions_panel_new RENAME TO sessions_panel;

--- a/rustmail/src/api/handler/user/avatar.rs
+++ b/rustmail/src/api/handler/user/avatar.rs
@@ -47,15 +47,25 @@ pub async fn handle_get_user_avatar(
         .await
     {
         Ok(record) => {
-            let avatar_hash: String = record.get::<String, _>("avatar_hash");
+            let avatar_hash: Option<String> = record.get::<Option<String>, _>("avatar_hash");
 
-            if !avatar_hash.is_empty() {
-                let avatar_url = format!(
-                    "https://cdn.discordapp.com/avatars/{}/{}.png",
-                    user_id_str, avatar_hash
-                );
-                UserAvatar {
-                    avatar_url: Some(avatar_url),
+            if let Some(hash) = avatar_hash {
+                if !hash.is_empty() {
+                    let avatar_url = format!(
+                        "https://cdn.discordapp.com/avatars/{}/{}.png",
+                        user_id_str, hash
+                    );
+                    UserAvatar {
+                        avatar_url: Some(avatar_url),
+                    }
+                } else {
+                    let avatar_url = format!(
+                        "https://cdn.discordapp.com/embed/avatars/{}.png",
+                        (user_id >> 22) % 6
+                    );
+                    UserAvatar {
+                        avatar_url: Some(avatar_url),
+                    }
                 }
             } else {
                 let avatar_url = format!(


### PR DESCRIPTION
This pull request updates the handling of Discord user avatars, allowing for users without a custom avatar to be supported. The migration modifies the database schema to allow `avatar_hash` to be nullable, and the API handler logic now correctly generates a default avatar URL when no custom hash is present.

**Database schema update:**

* Modified the `sessions_panel` table to allow `avatar_hash` to be `NULL`, enabling support for users without a Discord avatar.

**API handler improvements:**

* Updated the avatar retrieval logic in `handle_get_user_avatar` to treat `avatar_hash` as an `Option<String>`, handling cases where the value is missing.
* Added logic to generate a default Discord avatar URL when `avatar_hash` is `None`, based on the user ID.