### PR TITLE
fix(ci): force rust to use legacy symbol mangling

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Build frontend
         working-directory: rustmail_panel
+        env:
+          RUSTFLAGS: '-Csymbol-mangling-version=legacy -Zunstable-options'
         run: trunk build --release --dist ../rustmail/static --config Trunk.toml
 
       - name: Build Rust backend
@@ -98,6 +100,8 @@ jobs:
 
       - name: Build frontend
         working-directory: rustmail_panel
+        env:
+          RUSTFLAGS: '-Csymbol-mangling-version=legacy -Zunstable-options'
         run: trunk build --release --dist ../rustmail/static --config Trunk.toml
 
       - name: Verify static files were created


### PR DESCRIPTION
## Problem

The CI was failing during the frontend WASM build with the following error:

Uncaught SyntaxError: Identifier
'wasm_bindgen_4f453e33dd9327c9___convert__closures________invoke___web_sys_a88f6bde22b957e9___features__gen_Event__Event_____'
has already been declared

This error indicates that a JavaScript identifier is declared twice in the code generated by wasm-bindgen.

## Root Cause

The project uses Rust **nightly** (see `rust-toolchain.toml`), which enables the new **v0 symbol mangling** scheme by default.

The problem occurs during the following transformation chain:

1. **Rust compiles the code** with v0 mangling → generates unique WASM symbols
2. **wasm-bindgen processes the WASM** and uses `rustc-demangle` to convert symbols into JavaScript names
3. **rustc-demangle doesn't handle v0 mangling correctly** → two different symbols (e.g., closures with `Fn` vs `FnMut`) are
demangled to the same JavaScript name
4. **The final JS contains duplicate identifiers** → `SyntaxError`

This issue is documented in wasm-bindgen issue #4820: https://github.com/rustwasm/wasm-bindgen/issues/4820

## Solution

Force Rust to use **legacy symbol mangling** (instead of v0) by adding the following RUSTFLAGS during frontend builds:

```yaml
env:
  RUSTFLAGS: '-Csymbol-mangling-version=legacy -Zunstable-options'
```

Legacy mangling is properly supported by rustc-demangle, thus avoiding name collisions.

Changes

- Added RUSTFLAGS in .github/workflows/release-ci.yml to both frontend build steps:
    - build_and_test job (pre-release tests)
    - upload-assets job (release binaries build)

Notes

This solution is a temporary workaround until rustc-demangle and wasm-bindgen properly support v0 mangling. We can remove these flags once issue #4820 is resolved.

References

- wasm-bindgen issue #4820: https://github.com/rustwasm/wasm-bindgen/issues/4820