### PR TITLE
refactor(move): refactor move command format

### DIFF
--- a/rustmail/src/commands/move_thread/slash_command/move_thread.rs
+++ b/rustmail/src/commands/move_thread/slash_command/move_thread.rs
@@ -131,7 +131,7 @@ impl RegistrableCommand for MoveCommand {
 
                     let mut params = HashMap::new();
                     params.insert("category".to_string(), category_name.to_string());
-                    params.insert("staff".to_string(), command.user.name.clone());
+                    params.insert("staff".to_string(), command.user.id.to_string());
 
                     let response = MessageBuilder::system_message(&ctx, &config)
                         .translated_content(

--- a/rustmail/src/commands/move_thread/text_command/move_thread.rs
+++ b/rustmail/src/commands/move_thread/text_command/move_thread.rs
@@ -45,7 +45,7 @@ pub async fn move_thread(
 
             let mut params = HashMap::new();
             params.insert("category".to_string(), category_name.to_string());
-            params.insert("staff".to_string(), msg.author.name.clone());
+            params.insert("staff".to_string(), msg.author.id.to_string());
 
             let confirmation_msg = get_translated_message(
                 config,

--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -474,7 +474,7 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "move_thread.success".to_string(),
-        DictionaryMessage::new("✅ Thread moved to category '{category}' by {staff}")
+        DictionaryMessage::new("✅ Thread moved to category **{category}** by <@{staff}>")
             .with_description("The thread has been successfully moved to the new category"),
     );
     dict.messages.insert(
@@ -604,7 +604,9 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "close.auto_canceled_on_message".to_string(),
-        DictionaryMessage::new("Scheduled closure has been automatically canceled because a message was received."),
+        DictionaryMessage::new(
+            "Scheduled closure has been automatically canceled because a message was received.",
+        ),
     );
     dict.messages.insert(
         "close.replacing_existing_closure".to_string(),

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -502,7 +502,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "move_thread.success".to_string(),
-        DictionaryMessage::new("✅ Thread déplacé vers la catégorie '{category}' par {staff}")
+        DictionaryMessage::new("✅ Thread déplacé vers la catégorie **{category}** par <@{staff}>")
             .with_description("Le thread a été déplacé avec succès vers la nouvelle catégorie"),
     );
     dict.messages.insert(
@@ -632,7 +632,9 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "close.auto_canceled_on_message".to_string(),
-        DictionaryMessage::new("La fermeture programmée a été automatiquement annulée car un message a été reçu."),
+        DictionaryMessage::new(
+            "La fermeture programmée a été automatiquement annulée car un message a été reçu.",
+        ),
     );
     dict.messages.insert(
         "close.replacing_existing_closure".to_string(),


### PR DESCRIPTION
This pull request updates how staff information is displayed when moving threads, improving message clarity and user mentions. It also makes minor formatting changes to certain translated messages for consistency.

**Move thread staff identification and message formatting:**

* The `staff` parameter now uses the user's ID instead of their name when moving threads via both slash and text commands (`move_thread.rs`). This enables proper user mentions in confirmation messages.
* The success message for moving a thread now formats the category in bold and mentions the staff member using their Discord ID in both English and French translations (`en.rs`, `fr.rs`).

**Minor translation formatting:**

* The "auto canceled on message" translation is reformatted for code consistency in both English and French message files.