### PR TITLE
fix(thread): add warning when attachments are too big

### DIFF
--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -44,6 +44,10 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
             .with_description("An error occurred while communicating with Discord"),
     );
     dict.messages.insert(
+        "discord.attachment_too_large".to_string(),
+        DictionaryMessage::new("Your attachment is too large! Discord has a file size limit of 8 MB for attachments. Please reduce the file size or send a link."),
+    );
+    dict.messages.insert(
         "discord.user_is_a_bot".to_string(),
         DictionaryMessage::new("The specified user is a rustmail."),
     );

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -42,6 +42,10 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
             .with_description("Une erreur s'est produite lors de la communication avec Discord"),
     );
     dict.messages.insert(
+        "discord.attachment_too_large".to_string(),
+        DictionaryMessage::new("Votre pièce jointe est trop volumineuse ! Discord a une limite de taille de fichier de 8 Mo pour les pièces jointes. Veuillez réduire la taille du fichier ou envoyer un lien."),
+    );
+    dict.messages.insert(
         "discord.user_is_a_bot".to_string(),
         DictionaryMessage::new("L'utilisateur spécifié est un rustmail"),
     );

--- a/rustmail/src/modules/threads.rs
+++ b/rustmail/src/modules/threads.rs
@@ -140,6 +140,25 @@ pub async fn create_channel(ctx: &Context, msg: &Message, config: &Config) {
         return;
     }
 
+    const MAX_ATTACHMENT_SIZE: u32 = 8 * 1024 * 1024;
+    for attachment in &msg.attachments {
+        if attachment.size > MAX_ATTACHMENT_SIZE {
+            let _ = MessageBuilder::system_message(ctx, config)
+                .translated_content(
+                    "discord.attachment_too_large",
+                    None,
+                    Some(msg.author.id),
+                    None,
+                )
+                .await
+                .to_user(msg.author.id)
+                .send(true)
+                .await;
+
+            return;
+        }
+    }
+
     let (target_channel_id, _is_new_thread) =
         match create_or_get_thread_for_user(ctx, config, msg.author.id).await {
             Ok(res) => res,


### PR DESCRIPTION
This pull request introduces a new check for Discord message attachments to ensure they do not exceed the 8 MB file size limit, and adds localized error messages in both English and French to inform users when their attachments are too large.

**Attachment size validation:**

* Added a check in `guild_messages_handler.rs` and `threads.rs` to prevent forwarding or creating channels for messages with attachments larger than 8 MB. If such an attachment is detected, the user receives a system message and the operation is aborted. [[1]](diffhunk://#diff-f9203d144ed79a6e5d604fabba9d745c102fc8d92102cd9aa8bee92d46d56adbR146-R165) [[2]](diffhunk://#diff-49db2638bfe7b04b8e4e1a0d2d0aeb6d2faf3a00354db9a2d72110c6167cd328R143-R161)

**Internationalization updates:**

* Added a new English error message (`discord.attachment_too_large`) to inform users about the attachment size limit.
* Added a French translation for the new error message to ensure users receive the correct notification in their preferred language.