### PR TITLE
feat(logs): add logs when closing tickets

### DIFF
--- a/rustmail/src/commands/close/slash_command/close.rs
+++ b/rustmail/src/commands/close/slash_command/close.rs
@@ -362,6 +362,35 @@ impl RegistrableCommand for CloseCommand {
             .await?;
             let _ = delete_scheduled_closure(&thread.id, db_pool).await;
 
+            if config.bot.enable_logs {
+                if let Some(logs_channel_id) = config.bot.logs_channel_id {
+                    let base_url = config
+                        .bot
+                        .redirect_url
+                        .trim_end_matches("/api/auth/callback")
+                        .trim_end_matches('/');
+
+                    let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
+
+                    let mut params = HashMap::new();
+                    params.insert("username".to_string(), thread.user_name.clone());
+                    params.insert("user_id".to_string(), thread.user_id.to_string());
+                    params.insert("panel_url".to_string(), panel_url);
+
+                    let _ = MessageBuilder::system_message(&ctx, &config)
+                        .translated_content(
+                            "logs.ticket_closed",
+                            Some(&params),
+                            Some(command.user.id),
+                            command.guild_id.map(|g| g.get()),
+                        )
+                        .await
+                        .to_channel(serenity::all::ChannelId::new(logs_channel_id))
+                        .send(true)
+                        .await;
+                }
+            }
+
             let _ = command.channel_id.delete(&ctx.http).await?;
 
             Ok(())

--- a/rustmail/src/commands/force_close/text_command/force_close.rs
+++ b/rustmail/src/commands/force_close/text_command/force_close.rs
@@ -3,6 +3,7 @@ use crate::prelude::config::*;
 use crate::prelude::db::*;
 use crate::prelude::errors::*;
 use crate::prelude::handlers::*;
+use crate::prelude::utils::*;
 use serenity::all::{Context, Message};
 use std::sync::Arc;
 
@@ -26,11 +27,45 @@ pub async fn force_close(
         };
     }
 
+    let thread = get_thread_by_channel_id(&msg.channel_id.to_string(), db_pool).await;
+
     match is_orphaned_thread_channel(msg.channel_id, db_pool).await {
         Ok(res) => {
             if !res {
                 return Err(ModmailError::Thread(ThreadError::UserStillInServer));
             }
+
+            if let Some(thread_info) = thread {
+                if config.bot.enable_logs {
+                    if let Some(logs_channel_id) = config.bot.logs_channel_id {
+                        let base_url = config
+                            .bot
+                            .redirect_url
+                            .trim_end_matches("/api/auth/callback")
+                            .trim_end_matches('/');
+
+                        let panel_url = format!("{}/panel/tickets/{}", base_url, thread_info.id);
+
+                        let mut params = std::collections::HashMap::new();
+                        params.insert("username".to_string(), thread_info.user_name.clone());
+                        params.insert("user_id".to_string(), thread_info.user_id.to_string());
+                        params.insert("panel_url".to_string(), panel_url);
+
+                        let _ = MessageBuilder::system_message(&ctx, config)
+                            .translated_content(
+                                "logs.ticket_closed",
+                                Some(&params),
+                                Some(msg.author.id),
+                                msg.guild_id.map(|g| g.get()),
+                            )
+                            .await
+                            .to_channel(serenity::all::ChannelId::new(logs_channel_id))
+                            .send(true)
+                            .await;
+                    }
+                }
+            }
+
             delete_channel(&ctx, msg.channel_id).await
         }
         Err(..) => Err(ModmailError::Database(DatabaseError::QueryFailed(

--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -639,6 +639,10 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("This ticket will be closed silently in {time}."),
     );
     dict.messages.insert(
+        "logs.ticket_closed".to_string(),
+        DictionaryMessage::new("Ticket closed for user **{username}** (ID: {user_id})\n[View log on panel]({panel_url})"),
+    );
+    dict.messages.insert(
         "feature.not_implemented".to_string(),
         DictionaryMessage::new("This feature is not yet implemented."),
     );

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -661,6 +661,10 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("Ce ticket sera fermé silencieusement dans {time}."),
     );
     dict.messages.insert(
+        "logs.ticket_closed".to_string(),
+        DictionaryMessage::new("Ticket fermé pour l'utilisateur **{username}** (ID: {user_id})\n[Voir le log sur le panel]({panel_url})"),
+    );
+    dict.messages.insert(
         "feature.not_implemented".to_string(),
         DictionaryMessage::new("Cette feature n'est pas encore implémentée."),
     );


### PR DESCRIPTION
This pull request adds a new feature to log ticket closures in a dedicated logs channel, with contextual information and a link to the ticket panel, across both manual and scheduled closure flows. The change is implemented for close and force-close commands (both slash and text), as well as scheduled closure operations. It also introduces localized log messages in English and French.

### Logging and Notification Enhancements

* Added logic to send a log message to a configured logs channel whenever a ticket is closed (manual, force, or scheduled), including the user's name, user ID, and a direct link to the ticket panel. This is conditional on the `enable_logs` config setting and presence of a logs channel ID. (`rustmail/src/commands/close/slash_command/close.rs`, `rustmail/src/commands/close/text_command/close.rs`, `rustmail/src/commands/force_close/slash_command/force_close.rs`, `rustmail/src/commands/force_close/text_command/force_close.rs`, `rustmail/src/modules/scheduled_closures.rs`)

* Ensured that log messages are sent in both English and French, with appropriate translations for the ticket closure log entry. (`rustmail/src/i18n/language/en.rs`, `rustmail/src/i18n/language/fr.rs`)

### Codebase Maintenance

* Added necessary imports for utility functions used in the new logging logic. (`rustmail/src/commands/force_close/slash_command/force_close.rs`, `rustmail/src/commands/force_close/text_command/force_close.rs`)