### PR TITLE
refactor(panel): make the 'save configuration' button float

### DIFF
--- a/rustmail_panel/src/i18n/en/en.json
+++ b/rustmail_panel/src/i18n/en/en.json
@@ -121,6 +121,9 @@
       "save": "Save Configuration",
       "save_help": "A backup will be automatically created before saving",
       "save_success": "Configuration saved!",
+      "reset": "Reset",
+      "unsaved_changes": "Unsaved changes",
+      "save_button": "Save",
       "loading": "Loading...",
       "load_error": "Unable to load configuration",
       "restart_modal": {

--- a/rustmail_panel/src/i18n/fr/fr.json
+++ b/rustmail_panel/src/i18n/fr/fr.json
@@ -121,6 +121,9 @@
       "save": "Sauvegarder la Configuration",
       "save_help": "Un backup sera automatiquement créé avant la sauvegarde",
       "save_success": "Configuration sauvegardée !",
+      "reset": "Réinitialiser",
+      "unsaved_changes": "Modifications non sauvegardées",
+      "save_button": "Sauvegarder",
       "loading": "Chargement...",
       "load_error": "Impossible de charger la configuration",
       "restart_modal": {


### PR DESCRIPTION
This pull request enhances the configuration page UI and its save/reset workflow. The main improvements include a new floating save/reset bar for unsaved changes, better state management for saving, and updated translations for the new UI elements. These changes make it clearer to users when configuration changes are unsaved and provide a more intuitive way to save or reset their modifications.

**UI/UX Improvements:**

* Added a floating bar that appears when there are unsaved changes, allowing users to save or reset their configuration with animated transitions for better visibility.
* Updated the save button workflow to indicate saving state and prevent duplicate saves, improving user feedback during async operations.

**State Management and Logic:**

* After a successful save, the configuration is re-fetched from the API to ensure the UI reflects the latest saved state.

**Internationalization:**

* Added new translation keys for "Reset", "Unsaved changes", and "Save" in both English and French locale files to support the new UI elements.

**Code Style:**

* Minor formatting improvements for code consistency in the configuration and text input components.