### PR TITLE
refactor(snippet): implement 'use' subcommand to be more user-friendly

### DIFF
--- a/rustmail/src/handlers/guild_messages_handler.rs
+++ b/rustmail/src/handlers/guild_messages_handler.rs
@@ -78,7 +78,7 @@ impl GuildMessagesHandler {
         wrap_command!(lock, "take", take);
         wrap_command!(lock, "release", release);
         wrap_command!(lock, "ping", ping);
-        wrap_command!(lock, "snippet", snippet_command);
+        wrap_command!(lock, ["snippet", "s"], snippet_command);
 
         drop(lock);
         h

--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -981,10 +981,11 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
             • `/snippet list` - List all available snippets\n\
             • `/snippet show <key>` - Display a specific snippet's content\n\
             • `/snippet edit <key> <content>` - Update an existing snippet\n\
-            • `/snippet delete <key>` - Delete a snippet\n\n\
-            **Usage:**\n\
-            • Slash command: `/reply snippet:<key>`\n\
-            • Text command: `!reply {{key}}`",
+            • `/snippet delete <key>` - Delete a snippet\n\
+            • `/snippet use <key>` - Use a snippet to reply\n\n\
+            **Quick usage:**\n\
+            • Slash command: `/snippet use <key>` or `/reply snippet:<key>`\n\
+            • Text command: `!snippet <key>` or `!reply {{key}}`",
         ),
     );
     dict.messages.insert(
@@ -1006,6 +1007,10 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "slash_command.snippet_delete_description".to_string(),
         DictionaryMessage::new("Delete a snippet"),
+    );
+    dict.messages.insert(
+        "slash_command.snippet_use_description".to_string(),
+        DictionaryMessage::new("Use a snippet to reply in a ticket"),
     );
     dict.messages.insert(
         "slash_command.snippet_key_argument".to_string(),
@@ -1115,5 +1120,9 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new(
             "Unknown subcommand. Use: `create`, `list`, `show`, `edit`, or `delete`",
         ),
+    );
+    dict.messages.insert(
+        "snippet.used".to_string(),
+        DictionaryMessage::new("Snippet '**{key}**' used successfully!"),
     );
 }

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -992,10 +992,11 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
             • `/snippet list` - Lister tous les snippets disponibles\n\
             • `/snippet show <clé>` - Afficher le contenu d'un snippet spécifique\n\
             • `/snippet edit <clé> <contenu>` - Modifier un snippet existant\n\
-            • `/snippet delete <clé>` - Supprimer un snippet\n\n\
-            **Utilisation :**\n\
-            • Commande slash : `/reply snippet:<clé>`\n\
-            • Commande texte : `!reply {{clé}}`",
+            • `/snippet delete <clé>` - Supprimer un snippet\n\
+            • `/snippet use <clé>` - Utiliser un snippet pour répondre\n\n\
+            **Utilisation rapide :**\n\
+            • Commande slash : `/snippet use <clé>` ou `/reply snippet:<clé>`\n\
+            • Commande texte : `!snippet <clé>` ou `!reply {{clé}}`",
         ),
     );
     dict.messages.insert(
@@ -1017,6 +1018,10 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     dict.messages.insert(
         "slash_command.snippet_delete_description".to_string(),
         DictionaryMessage::new("Supprimer un snippet"),
+    );
+    dict.messages.insert(
+        "slash_command.snippet_use_description".to_string(),
+        DictionaryMessage::new("Utiliser un snippet pour répondre dans un ticket"),
     );
     dict.messages.insert(
         "slash_command.snippet_key_argument".to_string(),
@@ -1128,5 +1133,9 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new(
             "Sous-commande inconnue. Utilisez : `create`, `list`, `show`, `edit`, ou `delete`",
         ),
+    );
+    dict.messages.insert(
+        "snippet.used".to_string(),
+        DictionaryMessage::new("Snippet '**{key}**' utilisé avec succès !"),
     );
 }


### PR DESCRIPTION
This pull request introduces a new way to use snippets as replies in both slash and text commands, along with usability improvements and enhanced localization support. The most significant changes include adding a `/snippet use <key>` subcommand, allowing `!snippet <key>` as a shortcut for using a snippet, and updating help text and translations to reflect these new capabilities.

**New snippet usage functionality:**

* Added a `/snippet use <key>` subcommand to the slash command, enabling users to quickly use a snippet as a reply in a ticket. This includes backend logic for handling the new subcommand and appropriate user feedback.
* Enabled `!snippet <key>` (and alias `!s <key>`) as a text command shortcut for using a snippet, in addition to the existing `!reply {key}`.

**Improvements to argument parsing:**

* Refined parsing logic for the `create` and `edit` text commands to handle leading whitespace more robustly and extract the snippet key/content more reliably.

**Localization and help text updates:**

* Updated help and usage messages in both English and French to document the new `/snippet use` subcommand and the `!snippet <key>` shortcut, making it easier for users to discover these features.
* Added new translation keys and messages for the new subcommand and its responses in both languages.