### PR TITLE
refactor(api): add optionnal staff discord id to api external's 'createt ticket' endpoint

### DIFF
--- a/rustmail_types/src/api/mod.rs
+++ b/rustmail_types/src/api/mod.rs
@@ -20,6 +20,7 @@ pub struct ConfigResponse {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateTicket {
     pub discord_id: String,
+    pub staff_discord_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This pull request adds support for specifying an optional staff Discord ID when creating tickets via the external API. The changes ensure that if a staff member is provided, they are pinged in the ticket and receive a welcome message; otherwise, the previous behavior is preserved.

**API enhancements:**

* Added an optional `staff_discord_id` field to the `CreateTicket` struct in `rustmail_types/src/api/mod.rs`, allowing external callers to specify a staff member for ticket creation.

**Ticket creation logic updates:**

* Parsed and validated the optional staff Discord ID in `handle_external_ticket_create`, ensuring correct format and handling errors if invalid.
* Fetched the staff user if provided, with error handling for not-found users.

**Staff notification improvements:**

* If a valid staff user is provided and is not a bot, the staff member is pinged in the ticket channel and receives a welcome message; otherwise, the welcome message is sent only to the user.
* Improved logging to indicate when a staff member is pinged or if the staff user is a bot.