### PR TITLE
build(ci): switch to GitHub self hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,24 +21,14 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v4
+        with:
+          clean: 'false'
 
       - name: Setup Rust environment
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
           echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
-
-      - name: Cache Cargo dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            target
-          key: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
 
       - name: Build frontend
         working-directory: rustmail_panel

--- a/rustmail_panel/Trunk.toml
+++ b/rustmail_panel/Trunk.toml
@@ -5,4 +5,4 @@ generate-integrity = false
 [[hooks]]
 stage = "post_build"
 command = "sh"
-command_arguments = ["-c", "find ../rustmail/static -name '*.wasm' -exec wasm-opt --debug -Oz {} -o {} \\;"]
+command_arguments = ["-c", "find ../rustmail/static -name '*.wasm' -exec wasm-opt -Oz {} -o {} \\;"]


### PR DESCRIPTION
This pull request updates the CI workflow and build configuration to better support self-hosted runners and optimize the frontend build process. The most important changes are grouped below:

**CI Workflow Improvements**

* Changed the `runs-on` setting in `.github/workflows/ci.yml` to use `self-hosted` runners instead of `ubuntu-latest`, allowing for more control and potentially faster builds.
* Added the `clean: 'false'` option to the `actions/checkout` step, preserving files between workflow runs and improving build efficiency.
* Replaced the explicit Rust toolchain setup and installation commands with environment variable configuration for `CARGO_HOME` and `RUSTUP_HOME`, streamlining the Rust environment setup process.

**Frontend Build Optimization**

* Removed the `--debug` flag from the `wasm-opt` command in `rustmail_panel/Trunk.toml`, resulting in smaller WebAssembly binaries for production builds.