### PR TITLE
fix(reminder): retrieve thread by channel_id instead of user_id

### DIFF
--- a/rustmail/src/commands/add_reminder/text_command/add_reminder.rs
+++ b/rustmail/src/commands/add_reminder/text_command/add_reminder.rs
@@ -62,7 +62,7 @@ pub async fn add_reminder(
 
     let trigger_timestamp = trigger_dt.with_timezone(&config.bot.timezone).timestamp();
 
-    let thread = match get_thread_by_user_id(msg.author.id, pool).await {
+    let thread = match get_thread_by_channel_id(&msg.channel_id.to_string(), pool).await {
         Some(t) => t,
         None => {
             return Err(ModmailError::Thread(ThreadError::ThreadNotFound));


### PR DESCRIPTION
This pull request updates the logic for retrieving a thread when adding a reminder in the `add_reminder` text command. The code now searches for threads by channel ID instead of user ID, which better aligns with how reminders are associated with conversations.

Thread lookup update:

* Changed thread retrieval in `add_reminder.rs` to use `get_thread_by_channel_id` with the channel ID, rather than `get_thread_by_user_id` with the user ID.