### PR TITLE
refactor(close): add the staff who closed the ticket in close log message

### DIFF
--- a/rustmail/src/commands/close/slash_command/close.rs
+++ b/rustmail/src/commands/close/slash_command/close.rs
@@ -355,6 +355,7 @@ impl RegistrableCommand for CloseCommand {
                     let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
 
                     let mut params = HashMap::new();
+                    params.insert("staff".to_string(), command.user.id.to_string());
                     params.insert("username".to_string(), thread.user_name.clone());
                     params.insert("user_id".to_string(), thread.user_id.to_string());
                     params.insert("panel_url".to_string(), panel_url);

--- a/rustmail/src/commands/close/text_command/close.rs
+++ b/rustmail/src/commands/close/text_command/close.rs
@@ -295,6 +295,7 @@ pub async fn close(
             let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
 
             let mut params = HashMap::new();
+            params.insert("staff".to_string(), msg.author.id.to_string());
             params.insert("username".to_string(), thread.user_name.clone());
             params.insert("user_id".to_string(), thread.user_id.to_string());
             params.insert("panel_url".to_string(), panel_url);

--- a/rustmail/src/i18n/language/en.rs
+++ b/rustmail/src/i18n/language/en.rs
@@ -640,7 +640,7 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "logs.ticket_closed".to_string(),
-        DictionaryMessage::new("Ticket closed for user **{username}** (ID: {user_id})\n[View log on panel]({panel_url})"),
+        DictionaryMessage::new("Ticket closed by <@{staff}> for user **{username}** (ID: {user_id})\n[View log on panel]({panel_url})"),
     );
     dict.messages.insert(
         "feature.not_implemented".to_string(),

--- a/rustmail/src/i18n/language/fr.rs
+++ b/rustmail/src/i18n/language/fr.rs
@@ -662,7 +662,7 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
     );
     dict.messages.insert(
         "logs.ticket_closed".to_string(),
-        DictionaryMessage::new("Ticket fermé pour l'utilisateur **{username}** (ID: {user_id})\n[Voir le log sur le panel]({panel_url})"),
+        DictionaryMessage::new("Ticket fermé par <@{staff}> pour l'utilisateur **{username}** (ID: {user_id})\n[Voir le log sur le panel]({panel_url})"),
     );
     dict.messages.insert(
         "feature.not_implemented".to_string(),


### PR DESCRIPTION
This pull request updates the ticket closing functionality to include information about which staff member closed the ticket. The staff member's ID is now tracked and displayed in both the English and French log messages when a ticket is closed.

**Ticket closing improvements:**

* The `staff` field (containing the staff member's ID) is now added to the parameters when closing a ticket via both slash and text commands in `close.rs`.

**Internationalization updates:**

* The English log message for ticket closure (`logs.ticket_closed`) now states which staff member closed the ticket, using the new `{staff}` parameter.
* The French log message for ticket closure (`logs.ticket_closed`) was similarly updated to include the staff member who performed the closure.