### PR TITLE
fix(trads): add missing traductions for several audit log events

### DIFF
--- a/crates/rustmail/src/i18n/language/en.rs
+++ b/crates/rustmail/src/i18n/language/en.rs
@@ -1194,6 +1194,22 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("Unknown Member Action"),
     );
     dict.messages.insert(
+        "audit_log.member.pruned_count".to_string(),
+        DictionaryMessage::new("{count} members pruned"),
+    );
+    dict.messages.insert(
+        "audit_log.member.messages_deleted".to_string(),
+        DictionaryMessage::new("Messages deleted: {days} days"),
+    );
+    dict.messages.insert(
+        "audit_log.member.moved_to".to_string(),
+        DictionaryMessage::new("Moved to {channel} ({count} members)"),
+    );
+    dict.messages.insert(
+        "audit_log.member.disconnected_count".to_string(),
+        DictionaryMessage::new("{count} members disconnected"),
+    );
+    dict.messages.insert(
         "audit_log.channel.create".to_string(),
         DictionaryMessage::new("Channel Created"),
     );

--- a/crates/rustmail/src/i18n/language/fr.rs
+++ b/crates/rustmail/src/i18n/language/fr.rs
@@ -1207,6 +1207,22 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
         DictionaryMessage::new("Action Membre Inconnue"),
     );
     dict.messages.insert(
+        "audit_log.member.pruned_count".to_string(),
+        DictionaryMessage::new("{count} membres purgés"),
+    );
+    dict.messages.insert(
+        "audit_log.member.messages_deleted".to_string(),
+        DictionaryMessage::new("Messages supprimés : {days} jours"),
+    );
+    dict.messages.insert(
+        "audit_log.member.moved_to".to_string(),
+        DictionaryMessage::new("Déplacé vers {channel} ({count} membres)"),
+    );
+    dict.messages.insert(
+        "audit_log.member.disconnected_count".to_string(),
+        DictionaryMessage::new("{count} membres déconnectés"),
+    );
+    dict.messages.insert(
         "audit_log.channel.create".to_string(),
         DictionaryMessage::new("Salon Créé"),
     );


### PR DESCRIPTION
This pull request adds new audit log message templates for member-related actions in both English and French language files. These updates improve the application's ability to display localized messages for actions such as pruning members, deleting messages, moving members to channels, and disconnecting members.

**Localization updates for audit log messages:**

* Added new English message templates for member pruning, messages deleted, members moved to a channel, and members disconnected in `en.rs`.
* Added corresponding French message templates for the same member-related audit log actions in `fr.rs`.