### PR TITLE
fix(ci): fix ubuntu version for CI

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build_and_test:
     name: Rustmail - latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SQLX_OFFLINE: true
     strategy:
@@ -55,7 +55,7 @@ jobs:
   create-release:
     name: Create Release
     needs: build_and_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Create release
         env:
@@ -79,7 +79,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a specific Ubuntu version (`ubuntu-22.04`) instead of the default `ubuntu-latest` for several jobs. This change helps ensure consistent build environments and avoids unexpected issues caused by automatic updates to the latest runner image.

Workflow environment updates:

* Changed the `runs-on` parameter from `ubuntu-latest` to `ubuntu-22.04` in the `build_and_test` job to specify the exact Ubuntu version used for builds.
* Updated the `runs-on` parameter from `ubuntu-latest` to `ubuntu-22.04` in the `create-release` job for better consistency and reproducibility in release creation.
* Modified the matrix configuration to use `ubuntu-22.04` instead of `ubuntu-latest` for the `x86_64-unknown-linux-gnu` target, ensuring all Linux builds use the same runner version.