### PR TITLE
fix(panel): add error message when user is not allowed to acces panel

### DIFF
--- a/crates/rustmail_panel/src/pages/panel.rs
+++ b/crates/rustmail_panel/src/pages/panel.rs
@@ -58,10 +58,7 @@ pub fn panel() -> Html {
         if matches!(auth, Some(false)) {
             let win = window();
             if let Ok(pathname) = win.location().pathname() {
-                let redirect = urlencoding::encode(&pathname);
-                let _ = win
-                    .location()
-                    .set_href(&format!("/api/auth/login?redirect={}", redirect));
+                let _ = win.location().set_href("/error?message=Access+Denied");
             } else {
                 let _ = win.location().set_href("/api/auth/login");
             }


### PR DESCRIPTION
This pull request updates the authentication failure handling in the `panel` page. Now, instead of redirecting unauthenticated users to the login page with a redirect parameter, users are sent directly to an error page indicating "Access Denied".

Authentication flow update:

* Changed the redirect behavior for unauthenticated users in `panel.rs` so that they are now sent to `/error?message=Access+Denied` instead of the login page with a redirect parameter.