### PR TITLE
fix(bot): return translated error when moving ticket to a full Discord category

### DIFF
--- a/crates/rustmail/src/commands/move_thread/common.rs
+++ b/crates/rustmail/src/commands/move_thread/common.rs
@@ -1,10 +1,11 @@
-use crate::errors::{ModmailError, ModmailResult};
+use crate::errors::{DiscordError, ModmailError, ModmailResult};
 use crate::prelude::config::*;
 use crate::prelude::db::*;
 use crate::prelude::utils::*;
 use serenity::all::{
     ChannelId, CommandInteraction, Context, EditChannel, GuildChannel, GuildId, Message,
 };
+use serenity::http::HttpError;
 
 pub async fn is_in_thread(msg: &Message, pool: &sqlx::SqlitePool) -> bool {
     let channel_id = msg.channel_id.to_string();
@@ -46,6 +47,17 @@ pub async fn fetch_server_categories(ctx: &Context, config: &Config) -> Vec<(Cha
     }
 }
 
+fn map_move_error(err: serenity::Error) -> ModmailError {
+    if let serenity::Error::Http(HttpError::UnsuccessfulRequest(ref resp)) = err {
+        // 30013 = "Maximum number of guild channels reached"
+        // 30030 = "Maximum number of server categories reached"
+        if resp.error.code == 30013 || resp.error.code == 30030 {
+            return ModmailError::Discord(DiscordError::CategoryFull);
+        }
+    }
+    ModmailError::from(err)
+}
+
 pub async fn move_channel_to_category_by_msg(
     ctx: &Context,
     msg: &Message,
@@ -61,7 +73,7 @@ pub async fn move_channel_to_category_by_msg(
                 .permissions(permissions),
         )
         .await
-        .map_err(ModmailError::from)
+        .map_err(map_move_error)
 }
 
 pub async fn move_channel_to_category_by_command_option(
@@ -80,7 +92,7 @@ pub async fn move_channel_to_category_by_command_option(
                 .permissions(permissions),
         )
         .await
-        .map_err(ModmailError::from)
+        .map_err(map_move_error)
 }
 
 pub fn find_best_match_category(

--- a/crates/rustmail/src/errors/dictionary.rs
+++ b/crates/rustmail/src/errors/dictionary.rs
@@ -188,6 +188,7 @@ impl DictionaryManager {
                 DiscordError::ShardManagerNotFound => {
                     ("discord.shard_manager_not_found".to_string(), None)
                 }
+                DiscordError::CategoryFull => ("discord.category_full".to_string(), None),
                 _ => ("discord.api_error".to_string(), None),
             },
             ModmailError::Command(cmd_err) => match cmd_err {

--- a/crates/rustmail/src/errors/types.rs
+++ b/crates/rustmail/src/errors/types.rs
@@ -41,6 +41,7 @@ pub enum DiscordError {
     ChannelCreationFailed,
     FailedToFetchCategories,
     FailedToMoveChannel,
+    CategoryFull,
     ShardManagerNotFound,
 }
 
@@ -148,6 +149,7 @@ impl fmt::Display for DiscordError {
             DiscordError::ChannelCreationFailed => write!(f, "Failed to create channel"),
             DiscordError::FailedToFetchCategories => write!(f, "Failed to fetch categories"),
             DiscordError::FailedToMoveChannel => write!(f, "Failed to move_thread channel"),
+            DiscordError::CategoryFull => write!(f, "Discord category has too many channels"),
             DiscordError::ShardManagerNotFound => write!(f, "Shard manager not found"),
         }
     }

--- a/crates/rustmail/src/i18n/language/en.rs
+++ b/crates/rustmail/src/i18n/language/en.rs
@@ -44,6 +44,10 @@ pub fn load_english_messages(dict: &mut ErrorDictionary) {
             .with_description("An error occurred while communicating with Discord"),
     );
     dict.messages.insert(
+        "discord.category_full".to_string(),
+        DictionaryMessage::new("Unable to move the ticket: the target Discord category has reached the maximum number of channels. Please free up space or use a different category."),
+    );
+    dict.messages.insert(
         "discord.attachment_too_large".to_string(),
         DictionaryMessage::new("Your attachment is too large! Discord has a file size limit of 8 MB for attachments. Please reduce the file size or send a link."),
     );

--- a/crates/rustmail/src/i18n/language/fr.rs
+++ b/crates/rustmail/src/i18n/language/fr.rs
@@ -42,6 +42,10 @@ pub fn load_french_messages(dict: &mut ErrorDictionary) {
             .with_description("Une erreur s'est produite lors de la communication avec Discord"),
     );
     dict.messages.insert(
+        "discord.category_full".to_string(),
+        DictionaryMessage::new("Impossible de déplacer le ticket : la catégorie Discord cible a atteint le nombre maximum de salons. Libérez de l'espace ou utilisez une autre catégorie."),
+    );
+    dict.messages.insert(
         "discord.attachment_too_large".to_string(),
         DictionaryMessage::new("Votre pièce jointe est trop volumineuse ! Discord a une limite de taille de fichier de 8 Mo pour les pièces jointes. Veuillez réduire la taille du fichier ou envoyer un lien."),
     );


### PR DESCRIPTION
This pull request improves error handling when moving channels to Discord categories that have reached their maximum capacity. It introduces a new error type to represent this situation and ensures that users receive a clear, localized message when the error occurs.

**Error handling improvements:**

* Added a new `DiscordError::CategoryFull` variant to represent the case when a Discord category is full, and updated the error mapping logic in `move_thread/common.rs` to detect this specific error from Discord API responses.
* Updated the error message logic so that when `CategoryFull` occurs, a specific error message is returned instead of a generic Discord API error.

**Localization updates:**

* Added user-friendly, localized error messages for the new `discord.category_full` error in both English and French dictionaries, ensuring users are informed about the reason for the failure and possible next steps.

**Integration with move channel logic:**

* Updated the channel moving functions to use the new error mapping, so attempts to move a channel to a full category will properly trigger the new error and message.