### PR TITLE
feat(panel): implement wizard setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,7 @@ dependencies = [
  "base64",
  "cargo-husky",
  "chrono",
+ "chrono-tz",
  "futures",
  "hex",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
  "gloo-net 0.5.0",
  "gloo-render",
  "gloo-storage",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "gloo-utils 0.2.0",
  "gloo-worker",
 ]
@@ -1218,6 +1218,18 @@ name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2723,6 +2735,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "gloo-net 0.7.0",
+ "gloo-timers 0.4.0",
  "gloo-utils 0.3.0",
  "js-sys",
  "pulldown-cmark 0.13.4",

--- a/crates/rustmail/Cargo.toml
+++ b/crates/rustmail/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.22"
 moka = { version = "0.12.15", features = ["future"] }
 tower-http = { version = "0.7.0", features = ["compression-gzip", "compression-br"] }
 strum = { version = "0.28.0", features = ["derive"] }
+chrono-tz = "0.10.4"
 
 [dependencies.uuid]
 version = "1.23.3"

--- a/crates/rustmail/src/api/handler/admin/permissions.rs
+++ b/crates/rustmail/src/api/handler/admin/permissions.rs
@@ -58,20 +58,18 @@ pub async fn handle_list_permissions(
             row.try_get::<String, _>("permission"),
             row.try_get::<String, _>("granted_by"),
             row.try_get::<i64, _>("granted_at"),
+        ) && let (Some(st), Some(perm)) = (
+            SubjectType::from_str(&subject_type),
+            PanelPermission::from_str(&permission),
         ) {
-            if let (Some(st), Some(perm)) = (
-                SubjectType::from_str(&subject_type),
-                PanelPermission::from_str(&permission),
-            ) {
-                permissions.push(PanelPermissionEntry {
-                    id,
-                    subject_type: st,
-                    subject_id,
-                    permission: perm,
-                    granted_by,
-                    granted_at,
-                });
-            }
+            permissions.push(PanelPermissionEntry {
+                id,
+                subject_type: st,
+                subject_id,
+                permission: perm,
+                granted_by,
+                granted_at,
+            });
         }
     }
 

--- a/crates/rustmail/src/api/handler/auth/logout.rs
+++ b/crates/rustmail/src/api/handler/auth/logout.rs
@@ -24,7 +24,7 @@ pub async fn handle_logout(
 
     if let Some(session_cookie) = session_cookie {
         let session_id = session_cookie.value();
-        let user_id = get_user_id_from_session(&session_id, &db_pool).await;
+        let user_id = get_user_id_from_session(session_id, &db_pool).await;
 
         if let Some(db_pool) = &state_lock.db_pool {
             let _ = sqlx::query("DELETE FROM sessions_panel WHERE session_id = ? AND user_id = ?")

--- a/crates/rustmail/src/api/handler/bot/config.rs
+++ b/crates/rustmail/src/api/handler/bot/config.rs
@@ -1,10 +1,11 @@
-use crate::config::{Config, LanguageConfigExt, load_config};
+use crate::config::{
+    Config, LanguageConfigExt, load_config, save_config_with_backup, validate_config,
+};
 use crate::prelude::types::*;
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use rustmail_types::ConfigResponse;
-use std::fs;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -104,58 +105,4 @@ pub async fn handle_update_config(
         "success": true,
         "message": "Configuration saved successfully. Restart the bot to apply changes."
     })))
-}
-
-fn validate_config(config: &Config) -> Result<(), String> {
-    if u64::from_str_radix(&config.thread.user_message_color, 16).is_err() {
-        return Err("Invalid user message color format (must be hex)".to_string());
-    }
-
-    if u64::from_str_radix(&config.thread.staff_message_color, 16).is_err() {
-        return Err("Invalid staff message color format (must be hex)".to_string());
-    }
-
-    if u64::from_str_radix(&config.reminders.embed_color, 16).is_err() {
-        return Err("Invalid reminder embed color format (must be hex)".to_string());
-    }
-
-    config.bot.validate_logs_config()?;
-    config.bot.validate_features_config()?;
-
-    if !config
-        .language
-        .is_language_supported(config.language.get_default_language())
-    {
-        return Err(format!(
-            "Default language '{}' is not in supported languages list",
-            config.language.default_language
-        ));
-    }
-
-    Ok(())
-}
-
-async fn save_config_with_backup(config: &Config, path: &str) -> Result<(), String> {
-    if std::path::Path::new(path).exists() {
-        let backup_path = format!("{}.backup", path);
-        fs::copy(path, &backup_path).map_err(|e| format!("Failed to create backup: {}", e))?;
-    }
-
-    let config_response = ConfigResponse {
-        bot: config.bot.clone(),
-        command: config.command.clone(),
-        thread: config.thread.clone(),
-        language: config.language.clone(),
-        error_handling: config.error_handling.clone(),
-        notifications: config.notifications.clone(),
-        reminders: config.reminders.clone(),
-        logs: config.logs.clone(),
-    };
-
-    let toml_content = toml::to_string_pretty(&config_response)
-        .map_err(|e| format!("Failed to serialize config: {}", e))?;
-
-    fs::write(path, toml_content).map_err(|e| format!("Failed to write config file: {}", e))?;
-
-    Ok(())
 }

--- a/crates/rustmail/src/api/handler/bot/config.rs
+++ b/crates/rustmail/src/api/handler/bot/config.rs
@@ -1,6 +1,4 @@
-use crate::config::{
-    Config, LanguageConfigExt, load_config, save_config_with_backup, validate_config,
-};
+use crate::config::{Config, load_config, save_config_with_backup, validate_config};
 use crate::prelude::types::*;
 use axum::Json;
 use axum::extract::State;

--- a/crates/rustmail/src/api/handler/bot/tickets.rs
+++ b/crates/rustmail/src/api/handler/bot/tickets.rs
@@ -240,36 +240,35 @@ pub async fn handle_tickets_bot(
             messages,
         };
 
-        if !is_admin {
-            if let Some(ref category_id) = complete.category_id {
-                if !category_id.is_empty() {
-                    match get_user_permissions_in_category(
-                        &user_id,
-                        guild_id,
-                        category_id,
-                        bot_http.clone(),
-                    )
-                    .await
-                    {
-                        Some(perms) => {
-                            if !can_view_channel(perms) {
-                                return (
-                                    StatusCode::FORBIDDEN,
-                                    Json(serde_json::json!({
-                                        "error": "You don't have permission to view this ticket"
-                                    })),
-                                );
-                            }
-                        }
-                        None => {
-                            return (
-                                StatusCode::FORBIDDEN,
-                                Json(serde_json::json!({
-                                    "error": "Failed to check permissions"
-                                })),
-                            );
-                        }
+        if !is_admin
+            && let Some(ref category_id) = complete.category_id
+            && !category_id.is_empty()
+        {
+            match get_user_permissions_in_category(
+                &user_id,
+                guild_id,
+                category_id,
+                bot_http.clone(),
+            )
+            .await
+            {
+                Some(perms) => {
+                    if !can_view_channel(perms) {
+                        return (
+                            StatusCode::FORBIDDEN,
+                            Json(serde_json::json!({
+                                "error": "You don't have permission to view this ticket"
+                            })),
+                        );
                     }
+                }
+                None => {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        Json(serde_json::json!({
+                            "error": "Failed to check permissions"
+                        })),
+                    );
                 }
             }
         }
@@ -444,7 +443,7 @@ pub async fn handle_tickets_bot(
     for msg in all_messages {
         messages_by_thread
             .entry(msg.1.clone())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(ThreadMessage {
                 id: msg.0,
                 thread_id: msg.1.clone(),

--- a/crates/rustmail/src/api/handler/categories/categories.rs
+++ b/crates/rustmail/src/api/handler/categories/categories.rs
@@ -150,35 +150,35 @@ pub async fn update_category_handler(
             return Err((StatusCode::BAD_REQUEST, "Name required".to_string()));
         }
 
-        if let Some(conflict) = get_category_by_name(name, &p).await.map_err(internal)? {
-            if conflict.id != existing.id {
-                return Err((
-                    StatusCode::CONFLICT,
-                    "Category with this name already exists".to_string(),
-                ));
-            }
-        }
-    }
-
-    if let Some(true) = req.enabled {
-        if !existing.enabled {
-            let enabled_count = count_enabled_categories(&p).await.map_err(internal)?;
-            if enabled_count as usize >= CATEGORY_BUTTON_HARD_LIMIT {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!("Maximum {} enabled categories", CATEGORY_BUTTON_HARD_LIMIT),
-                ));
-            }
-        }
-    }
-
-    if let Some(ref did) = req.discord_category_id {
-        if did.parse::<u64>().is_err() {
+        if let Some(conflict) = get_category_by_name(name, &p).await.map_err(internal)?
+            && conflict.id != existing.id
+        {
             return Err((
-                StatusCode::BAD_REQUEST,
-                "Invalid discord_category_id".to_string(),
+                StatusCode::CONFLICT,
+                "Category with this name already exists".to_string(),
             ));
         }
+    }
+
+    if let Some(true) = req.enabled
+        && !existing.enabled
+    {
+        let enabled_count = count_enabled_categories(&p).await.map_err(internal)?;
+        if enabled_count as usize >= CATEGORY_BUTTON_HARD_LIMIT {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("Maximum {} enabled categories", CATEGORY_BUTTON_HARD_LIMIT),
+            ));
+        }
+    }
+
+    if let Some(ref did) = req.discord_category_id
+        && did.parse::<u64>().is_err()
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Invalid discord_category_id".to_string(),
+        ));
     }
 
     update_category(

--- a/crates/rustmail/src/api/handler/health.rs
+++ b/crates/rustmail/src/api/handler/health.rs
@@ -12,10 +12,10 @@ pub async fn handle_health(State(bot_state): State<Arc<Mutex<BotState>>>) -> imp
     let state_lock = bot_state.lock().await;
 
     let mut db_ok = false;
-    if let Some(pool) = &state_lock.db_pool {
-        if sqlx::query("SELECT 1").execute(pool).await.is_ok() {
-            db_ok = true;
-        }
+    if let Some(pool) = &state_lock.db_pool
+        && sqlx::query("SELECT 1").execute(pool).await.is_ok()
+    {
+        db_ok = true;
     }
 
     let bot_running = matches!(state_lock.status, BotStatus::Running { .. });

--- a/crates/rustmail/src/api/middleware/auth.rs
+++ b/crates/rustmail/src/api/middleware/auth.rs
@@ -51,10 +51,7 @@ async fn check_user_with_api(
         Err(_) => return false,
     };
 
-    match guild_id.member(bot_http, user_id).await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    guild_id.member(bot_http, user_id).await.is_ok()
 }
 
 async fn verify_user(user_id: &str, guild_id: u64, bot_state: Arc<Mutex<BotState>>) -> bool {
@@ -101,32 +98,32 @@ pub async fn auth_middleware(
         }
     };
 
-    if let Some(api_key_header) = req.headers().get("x-api-key") {
-        if let Ok(api_key_str) = api_key_header.to_str() {
-            let key_hash = hash_api_key(api_key_str);
+    if let Some(api_key_header) = req.headers().get("x-api-key")
+        && let Ok(api_key_str) = api_key_header.to_str()
+    {
+        let key_hash = hash_api_key(api_key_str);
 
-            return match get_api_key_by_hash(&db_pool, &key_hash).await {
-                Ok(Some(api_key)) => {
-                    if api_key.is_valid() {
-                        let pool_clone = db_pool.clone();
-                        let key_id = api_key.id;
-                        tokio::spawn(async move {
-                            let _ = update_last_used(&pool_clone, key_id).await;
-                        });
+        return match get_api_key_by_hash(&db_pool, &key_hash).await {
+            Ok(Some(api_key)) => {
+                if api_key.is_valid() {
+                    let pool_clone = db_pool.clone();
+                    let key_id = api_key.id;
+                    tokio::spawn(async move {
+                        let _ = update_last_used(&pool_clone, key_id).await;
+                    });
 
-                        req.extensions_mut().insert(api_key);
-                        next.run(req).await
-                    } else {
-                        (StatusCode::UNAUTHORIZED, "API key expired or inactive").into_response()
-                    }
+                    req.extensions_mut().insert(api_key);
+                    next.run(req).await
+                } else {
+                    (StatusCode::UNAUTHORIZED, "API key expired or inactive").into_response()
                 }
-                Ok(None) => (StatusCode::UNAUTHORIZED, "Invalid API key").into_response(),
-                Err(e) => {
-                    eprintln!("Error fetching API key: {}", e);
-                    (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
-                }
-            };
-        }
+            }
+            Ok(None) => (StatusCode::UNAUTHORIZED, "Invalid API key").into_response(),
+            Err(e) => {
+                eprintln!("Error fetching API key: {}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
+            }
+        };
     }
 
     let session_cookie = jar.get("session_id");

--- a/crates/rustmail/src/api/router.rs
+++ b/crates/rustmail/src/api/router.rs
@@ -14,7 +14,7 @@ pub fn create_api_router(bot_state: Arc<Mutex<BotState>>) -> Router {
     let user_router = create_user_router(bot_state.clone());
     let external_router = create_external_router(bot_state.clone());
 
-    let app = Router::new()
+    Router::new()
         .route("/api/health", axum::routing::get(handle_health))
         .nest("/api/admin", admin_router)
         .nest("/api/apikeys", apikeys_router)
@@ -24,7 +24,5 @@ pub fn create_api_router(bot_state: Arc<Mutex<BotState>>) -> Router {
         .nest("/api/panel", panel_router)
         .nest("/api/user", user_router)
         .nest("/api/externals", external_router)
-        .with_state(bot_state.clone());
-
-    app
+        .with_state(bot_state.clone())
 }

--- a/crates/rustmail/src/api/routes/apikeys.rs
+++ b/crates/rustmail/src/api/routes/apikeys.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub fn create_apikeys_router(bot_state: Arc<Mutex<BotState>>) -> Router<Arc<Mutex<BotState>>> {
-    let apikeys_router = Router::new()
+    Router::new()
         .route("/", post(create_api_key_handler))
         .route("/", get(list_api_keys_handler))
         .route("/{id}/revoke", post(revoke_api_key_handler))
@@ -21,7 +21,5 @@ pub fn create_apikeys_router(bot_state: Arc<Mutex<BotState>>) -> Router<Arc<Mute
         .layer(axum::middleware::from_fn_with_state(
             bot_state,
             auth_middleware,
-        ));
-
-    apikeys_router
+        ))
 }

--- a/crates/rustmail/src/api/routes/auth.rs
+++ b/crates/rustmail/src/api/routes/auth.rs
@@ -6,10 +6,8 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub fn create_auth_router() -> Router<Arc<Mutex<BotState>>> {
-    let auth_router = Router::new()
+    Router::new()
         .route("/login", get(handle_login))
         .route("/callback", get(handle_callback))
-        .route("/logout", get(handle_logout));
-
-    auth_router
+        .route("/logout", get(handle_logout))
 }

--- a/crates/rustmail/src/api/routes/bot.rs
+++ b/crates/rustmail/src/api/routes/bot.rs
@@ -42,14 +42,12 @@ pub fn create_bot_router(bot_state: Arc<Mutex<BotState>>) -> Router<Arc<Mutex<Bo
             },
         ));
 
-    let bot_router = Router::new()
+    Router::new()
         .merge(manage_bot_routes)
         .merge(manage_config_routes)
         .merge(view_routes)
         .layer(axum::middleware::from_fn_with_state(
             bot_state,
             auth_middleware,
-        ));
-
-    bot_router
+        ))
 }

--- a/crates/rustmail/src/api/routes/externals/mod.rs
+++ b/crates/rustmail/src/api/routes/externals/mod.rs
@@ -10,12 +10,10 @@ use tokio::sync::Mutex;
 pub fn create_external_router(bot_state: Arc<Mutex<BotState>>) -> Router<Arc<Mutex<BotState>>> {
     let external_tickets_router = create_external_ticket_router(bot_state.clone());
 
-    let bot_router = Router::new()
+    Router::new()
         .nest("/tickets", external_tickets_router)
         .layer(axum::middleware::from_fn_with_state(
             bot_state,
             auth_middleware,
-        ));
-
-    bot_router
+        ))
 }

--- a/crates/rustmail/src/api/routes/externals/tickets.rs
+++ b/crates/rustmail/src/api/routes/externals/tickets.rs
@@ -8,12 +8,10 @@ use tokio::sync::Mutex;
 pub fn create_external_ticket_router(
     bot_state: Arc<Mutex<BotState>>,
 ) -> Router<Arc<Mutex<BotState>>> {
-    let bot_router = Router::new()
+    Router::new()
         .route("/create", post(handle_external_ticket_create))
         .layer(axum::middleware::from_fn_with_state(
             bot_state,
             auth_middleware,
-        ));
-
-    bot_router
+        ))
 }

--- a/crates/rustmail/src/api/routes/panel.rs
+++ b/crates/rustmail/src/api/routes/panel.rs
@@ -6,12 +6,10 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub fn create_panel_router(bot_state: Arc<Mutex<BotState>>) -> Router<Arc<Mutex<BotState>>> {
-    let panel_router = Router::new()
+    Router::new()
         .route("/check", get(handle_panel_check))
         .layer(axum::middleware::from_fn_with_state(
             bot_state,
             auth_middleware,
-        ));
-
-    panel_router
+        ))
 }

--- a/crates/rustmail/src/api/routes/user.rs
+++ b/crates/rustmail/src/api/routes/user.rs
@@ -6,13 +6,11 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub fn create_user_router(bot_state: Arc<Mutex<BotState>>) -> Router<Arc<Mutex<BotState>>> {
-    let user_router = Router::new()
+    Router::new()
         .route("/avatar", get(handle_get_user_avatar))
         .route("/permissions", get(handle_get_user_permissions))
         .layer(axum::middleware::from_fn_with_state(
             bot_state,
             auth_middleware,
-        ));
-
-    user_router
+        ))
 }

--- a/crates/rustmail/src/api/utils/panel_permissions.rs
+++ b/crates/rustmail/src/api/utils/panel_permissions.rs
@@ -100,12 +100,11 @@ pub async fn get_user_panel_permissions(
     .await
     {
         for row in rows {
-            if let Ok(perm_str) = row.try_get::<String, _>("permission") {
-                if let Some(perm) = PanelPermission::from_str(&perm_str) {
-                    if !permissions.contains(&perm) {
-                        permissions.push(perm);
-                    }
-                }
+            if let Ok(perm_str) = row.try_get::<String, _>("permission")
+                && let Some(perm) = PanelPermission::from_str(&perm_str)
+                && !permissions.contains(&perm)
+            {
+                permissions.push(perm);
             }
         }
     }
@@ -130,12 +129,11 @@ pub async fn get_user_panel_permissions(
     .await
     {
         for row in rows {
-            if let Ok(perm_str) = row.try_get::<String, _>("permission") {
-                if let Some(perm) = PanelPermission::from_str(&perm_str) {
-                    if !permissions.contains(&perm) {
-                        permissions.push(perm);
-                    }
-                }
+            if let Ok(perm_str) = row.try_get::<String, _>("permission")
+                && let Some(perm) = PanelPermission::from_str(&perm_str)
+                && !permissions.contains(&perm)
+            {
+                permissions.push(perm);
             }
         }
     }
@@ -151,13 +149,11 @@ pub async fn get_user_panel_permissions(
             .await
             {
                 for row in rows {
-                    if let Ok(perm_str) = row.try_get::<String, _>("permission") {
-                        if let Some(perm) = PanelPermission::from_str(&perm_str) {
-                            if !permissions.contains(&perm) {
+                    if let Ok(perm_str) = row.try_get::<String, _>("permission")
+                        && let Some(perm) = PanelPermission::from_str(&perm_str)
+                            && !permissions.contains(&perm) {
                                 permissions.push(perm);
                             }
-                        }
-                    }
                 }
             }
         }

--- a/crates/rustmail/src/api/utils/user_permissions.rs
+++ b/crates/rustmail/src/api/utils/user_permissions.rs
@@ -90,13 +90,13 @@ pub async fn get_user_permissions_in_category(
         .unwrap_or(0u64);
 
     for overwrite in &category.permission_overwrites {
-        if let PermissionOverwriteType::Role(role_id) = overwrite.kind {
-            if role_id == everyone_role_id {
-                let deny = overwrite.deny.bits();
-                let allow = overwrite.allow.bits();
-                permissions = (permissions & !deny) | allow;
-                break;
-            }
+        if let PermissionOverwriteType::Role(role_id) = overwrite.kind
+            && role_id == everyone_role_id
+        {
+            let deny = overwrite.deny.bits();
+            let allow = overwrite.allow.bits();
+            permissions = (permissions & !deny) | allow;
+            break;
         }
     }
 
@@ -105,11 +105,11 @@ pub async fn get_user_permissions_in_category(
 
     for role_id in &member.roles {
         for overwrite in &category.permission_overwrites {
-            if let PermissionOverwriteType::Role(overwrite_role_id) = overwrite.kind {
-                if overwrite_role_id == *role_id {
-                    combined_allow |= overwrite.allow.bits();
-                    combined_deny |= overwrite.deny.bits();
-                }
+            if let PermissionOverwriteType::Role(overwrite_role_id) = overwrite.kind
+                && overwrite_role_id == *role_id
+            {
+                combined_allow |= overwrite.allow.bits();
+                combined_deny |= overwrite.deny.bits();
             }
         }
     }
@@ -117,13 +117,13 @@ pub async fn get_user_permissions_in_category(
     permissions = (permissions & !combined_deny) | combined_allow;
 
     for overwrite in &category.permission_overwrites {
-        if let PermissionOverwriteType::Member(member_id) = overwrite.kind {
-            if member_id == user_id_obj {
-                let deny = overwrite.deny.bits();
-                let allow = overwrite.allow.bits();
-                permissions = (permissions & !deny) | allow;
-                break;
-            }
+        if let PermissionOverwriteType::Member(member_id) = overwrite.kind
+            && member_id == user_id_obj
+        {
+            let deny = overwrite.deny.bits();
+            let allow = overwrite.allow.bits();
+            permissions = (permissions & !deny) | allow;
+            break;
         }
     }
 

--- a/crates/rustmail/src/bot.rs
+++ b/crates/rustmail/src/bot.rs
@@ -22,11 +22,11 @@ impl TypeMapKey for ShardManagerKey {
     type Value = Arc<ShardManager>;
 }
 
-pub async fn init_bot_state() -> Arc<Mutex<BotState>> {
+pub async fn init_bot_state(config_path: &str) -> Arc<Mutex<BotState>> {
     let pool = init_database().await.expect("An error occurred!");
     println!("Database connected!");
 
-    let config = load_config("config.toml");
+    let config = load_config(config_path);
 
     let (command_tx, _command_rx) = tokio::sync::mpsc::channel(32);
 

--- a/crates/rustmail/src/commands/add_reminder/common.rs
+++ b/crates/rustmail/src/commands/add_reminder/common.rs
@@ -51,7 +51,7 @@ pub async fn send_register_confirmation_from_message(
         (false, false) => "reminder.registered_without_content",
     };
 
-    let _ = MessageBuilder::system_message(&ctx, &config)
+    let _ = MessageBuilder::system_message(ctx, config)
         .translated_content(key, Some(&params), None, None)
         .await
         .to_channel(msg.channel_id)
@@ -100,12 +100,12 @@ pub async fn send_register_confirmation_from_command(
         (false, false) => "reminder.registered_without_content",
     };
 
-    let _ = MessageBuilder::system_message(&ctx, &config)
+    let _ = MessageBuilder::system_message(ctx, config)
         .translated_content(key, Some(&params), None, None)
         .await
         .to_channel(command.channel_id)
         .footer(format!("{}: {}", "ID", reminder_id))
-        .send_interaction_followup(&command, true)
+        .send_interaction_followup(command, true)
         .await;
 }
 

--- a/crates/rustmail/src/commands/add_reminder/slash_command/add_reminder.rs
+++ b/crates/rustmail/src/commands/add_reminder/slash_command/add_reminder.rs
@@ -156,7 +156,7 @@ impl RegistrableCommand for AddReminderCommand {
             let re = Regex::new(r"^(?P<hour>[01]?\d|2[0-3]):(?P<minute>[0-5]\d)$").unwrap();
             let captures = re
                 .captures(&time_str)
-                .ok_or_else(|| ModmailError::Command(CommandError::InvalidReminderFormat))?;
+                .ok_or(ModmailError::Command(CommandError::InvalidReminderFormat))?;
 
             let hours: u32 = captures
                 .name("hour")
@@ -232,7 +232,7 @@ impl RegistrableCommand for AddReminderCommand {
                 Some(reminder_id),
                 &ctx,
                 &config,
-                &pool,
+                pool,
                 handler.shutdown.clone(),
             );
 
@@ -260,12 +260,12 @@ async fn resolve_role_names_to_ids(
     let mut role_ids: Vec<u64> = Vec::new();
 
     for caps in mention_regex.captures_iter(roles_str) {
-        if let Some(id_match) = caps.get(1) {
-            if let Ok(id) = id_match.as_str().parse::<u64>() {
-                if guild.roles.contains_key(&RoleId::new(id)) && !role_ids.contains(&id) {
-                    role_ids.push(id);
-                }
-            }
+        if let Some(id_match) = caps.get(1)
+            && let Ok(id) = id_match.as_str().parse::<u64>()
+            && guild.roles.contains_key(&RoleId::new(id))
+            && !role_ids.contains(&id)
+        {
+            role_ids.push(id);
         }
     }
 
@@ -282,10 +282,9 @@ async fn resolve_role_names_to_ids(
                 .roles
                 .values()
                 .find(|r| r.name.to_lowercase() == role_name_lower)
+                && !role_ids.contains(&role.id.get())
             {
-                if !role_ids.contains(&role.id.get()) {
-                    role_ids.push(role.id.get());
-                }
+                role_ids.push(role.id.get());
             }
         }
     }

--- a/crates/rustmail/src/commands/add_reminder/text_command/add_reminder.rs
+++ b/crates/rustmail/src/commands/add_reminder/text_command/add_reminder.rs
@@ -49,8 +49,8 @@ pub async fn add_reminder(
 
     let re = Regex::new(r"^(?P<hour>[01]?\d|2[0-3]):(?P<minute>[0-5]\d)$").unwrap();
     let captures = re
-        .captures(&duration_str)
-        .ok_or_else(|| ModmailError::Command(CommandError::InvalidReminderFormat))?;
+        .captures(duration_str)
+        .ok_or(ModmailError::Command(CommandError::InvalidReminderFormat))?;
 
     let hours: u32 = captures
         .name("hour")
@@ -124,8 +124,8 @@ pub async fn add_reminder(
         &reminder,
         Some(reminder_id),
         &ctx,
-        &config,
-        &pool,
+        config,
+        pool,
         handler.shutdown.clone(),
     );
 

--- a/crates/rustmail/src/commands/add_staff/text_command/add_staff.rs
+++ b/crates/rustmail/src/commands/add_staff/text_command/add_staff.rs
@@ -30,7 +30,7 @@ pub async fn add_staff(
     }
 
     let parsed =
-        parse_add_target(&raw).ok_or_else(|| ModmailError::Command(CommandError::InvalidFormat))?;
+        parse_add_target(&raw).ok_or(ModmailError::Command(CommandError::InvalidFormat))?;
 
     let guild_id = msg
         .guild_id

--- a/crates/rustmail/src/commands/alert/common.rs
+++ b/crates/rustmail/src/commands/alert/common.rs
@@ -66,9 +66,7 @@ pub async fn handle_cancel_alert_from_msg(
     user_id: i64,
     pool: &sqlx::SqlitePool,
 ) -> ModmailResult<()> {
-    if let Err(e) = cancel_alert_for_staff(msg.author.id, user_id, pool).await {
-        return Err(e);
-    }
+    cancel_alert_for_staff(msg.author.id, user_id, pool).await?;
 
     let mut params = HashMap::new();
     params.insert("user".to_string(), format!("<@{}>", user_id));

--- a/crates/rustmail/src/commands/anonreply/text_command/anonreply.rs
+++ b/crates/rustmail/src/commands/anonreply/text_command/anonreply.rs
@@ -23,18 +23,18 @@ pub async fn anonreply(
     let mut content =
         extract_reply_content(&msg.content, &config.command.prefix, &["anonreply", "ar"]);
 
-    if let Some(text) = &content {
-        if let Some(stripped) = text.strip_prefix("{{").and_then(|s| s.strip_suffix("}}")) {
-            let snippet_key = stripped.trim();
-            match get_snippet_by_key(snippet_key, db_pool).await? {
-                Some(snippet) => {
-                    content = Some(snippet.content);
-                }
-                None => {
-                    return Err(ModmailError::Command(CommandError::SnippetNotFound(
-                        snippet_key.to_string(),
-                    )));
-                }
+    if let Some(text) = &content
+        && let Some(stripped) = text.strip_prefix("{{").and_then(|s| s.strip_suffix("}}"))
+    {
+        let snippet_key = stripped.trim();
+        match get_snippet_by_key(snippet_key, db_pool).await? {
+            Some(snippet) => {
+                content = Some(snippet.content);
+            }
+            None => {
+                return Err(ModmailError::Command(CommandError::SnippetNotFound(
+                    snippet_key.to_string(),
+                )));
             }
         }
     }

--- a/crates/rustmail/src/commands/baninfo/slash_command/baninfo.rs
+++ b/crates/rustmail/src/commands/baninfo/slash_command/baninfo.rs
@@ -82,18 +82,17 @@ impl RegistrableCommand for BaninfoCommand {
 
             let mut query: Option<String> = None;
             for option in &command.data.options {
-                if option.name.as_str() == "query" {
-                    if let CommandDataOptionValue::String(val) = &option.value {
-                        let trimmed = val.trim();
-                        if !trimmed.is_empty() {
-                            query = Some(trimmed.to_string());
-                        }
+                if option.name.as_str() == "query"
+                    && let CommandDataOptionValue::String(val) = &option.value
+                {
+                    let trimmed = val.trim();
+                    if !trimmed.is_empty() {
+                        query = Some(trimmed.to_string());
                     }
                 }
             }
 
-            let query =
-                query.ok_or_else(|| ModmailError::Command(CommandError::MissingArguments))?;
+            let query = query.ok_or(ModmailError::Command(CommandError::MissingArguments))?;
             let guild_id = config.bot.get_community_guild_id().to_string();
             let matches = resolve_banned_users(&guild_id, &query, pool).await?;
 

--- a/crates/rustmail/src/commands/category/slash_command/category.rs
+++ b/crates/rustmail/src/commands/category/slash_command/category.rs
@@ -324,10 +324,10 @@ fn get_string(opts: &[CommandDataOption], key: &str) -> Option<String> {
     let sub = opts.first()?;
     if let CommandDataOptionValue::SubCommand(sub_opts) = &sub.value {
         for o in sub_opts {
-            if o.name == key {
-                if let CommandDataOptionValue::String(s) = &o.value {
-                    return Some(s.clone());
-                }
+            if o.name == key
+                && let CommandDataOptionValue::String(s) = &o.value
+            {
+                return Some(s.clone());
             }
         }
     }
@@ -338,10 +338,10 @@ fn get_int(opts: &[CommandDataOption], key: &str) -> Option<i64> {
     let sub = opts.first()?;
     if let CommandDataOptionValue::SubCommand(sub_opts) = &sub.value {
         for o in sub_opts {
-            if o.name == key {
-                if let CommandDataOptionValue::Integer(v) = &o.value {
-                    return Some(*v);
-                }
+            if o.name == key
+                && let CommandDataOptionValue::Integer(v) = &o.value
+            {
+                return Some(*v);
             }
         }
     }
@@ -533,10 +533,10 @@ async fn sub_rename(
         Some(c) => c,
         None => return reply(ctx, command, config, "category.not_found", None).await,
     };
-    if let Some(existing) = get_category_by_name(&new, pool).await? {
-        if existing.id != cat.id {
-            return reply(ctx, command, config, "category.already_exists", None).await;
-        }
+    if let Some(existing) = get_category_by_name(&new, pool).await?
+        && existing.id != cat.id
+    {
+        return reply(ctx, command, config, "category.already_exists", None).await;
     }
     update_category(&cat.id, Some(&new), None, None, None, None, None, pool).await?;
     let mut params = HashMap::new();
@@ -667,10 +667,10 @@ fn get_sub_group_options(options: &[CommandDataOption]) -> Option<(&str, &Vec<Co
 
 fn leaf_string(opts: &[CommandDataOption], key: &str) -> Option<String> {
     for o in opts {
-        if o.name == key {
-            if let CommandDataOptionValue::String(s) = &o.value {
-                return Some(s.clone());
-            }
+        if o.name == key
+            && let CommandDataOptionValue::String(s) = &o.value
+        {
+            return Some(s.clone());
         }
     }
     None
@@ -678,10 +678,10 @@ fn leaf_string(opts: &[CommandDataOption], key: &str) -> Option<String> {
 
 fn leaf_role(opts: &[CommandDataOption], key: &str) -> Option<u64> {
     for o in opts {
-        if o.name == key {
-            if let CommandDataOptionValue::Role(r) = &o.value {
-                return Some(r.get());
-            }
+        if o.name == key
+            && let CommandDataOptionValue::Role(r) = &o.value
+        {
+            return Some(r.get());
         }
     }
     None

--- a/crates/rustmail/src/commands/category/text_command/category.rs
+++ b/crates/rustmail/src/commands/category/text_command/category.rs
@@ -82,7 +82,6 @@ async fn handle_create(
     pool: &sqlx::SqlitePool,
     config: &Config,
 ) -> ModmailResult<()> {
-    // Format: <discord_category_id> <name> [| description] [| emoji]
     let mut parts = args.splitn(2, ' ');
     let discord_id_raw = parts.next().unwrap_or("").trim();
     let rest = parts.next().unwrap_or("").trim();
@@ -212,10 +211,10 @@ async fn handle_rename(
         Some(c) => c,
         None => return send_translated(ctx, config, msg, "category.not_found", None).await,
     };
-    if let Some(existing) = get_category_by_name(new, pool).await? {
-        if existing.id != cat.id {
-            return send_translated(ctx, config, msg, "category.already_exists", None).await;
-        }
+    if let Some(existing) = get_category_by_name(new, pool).await?
+        && existing.id != cat.id
+    {
+        return send_translated(ctx, config, msg, "category.already_exists", None).await;
     }
     update_category(&cat.id, Some(new), None, None, None, None, None, pool).await?;
     let mut params = HashMap::new();

--- a/crates/rustmail/src/commands/close/slash_command/close.rs
+++ b/crates/rustmail/src/commands/close/slash_command/close.rs
@@ -139,10 +139,10 @@ impl RegistrableCommand for CloseCommand {
                 }
             }
 
-            if let Some(time_before_close) = time_before_close {
-                if let Some(dur) = parse_duration_spec(&time_before_close) {
-                    duration = Some(dur);
-                }
+            if let Some(time_before_close) = time_before_close
+                && let Some(dur) = parse_duration_spec(&time_before_close)
+            {
+                duration = Some(dur);
             }
 
             let thread = fetch_thread(db_pool, &command.channel_id.to_string()).await?;
@@ -175,16 +175,16 @@ impl RegistrableCommand for CloseCommand {
                 };
             }
 
-            if duration.is_none() {
-                if let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await {
-                    let remaining = existing.close_at - Utc::now().timestamp();
+            if duration.is_none()
+                && let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await
+            {
+                let remaining = existing.close_at - Utc::now().timestamp();
 
-                    let mut params = HashMap::new();
-                    params.insert("seconds".to_string(), remaining.to_string());
+                let mut params = HashMap::new();
+                params.insert("seconds".to_string(), remaining.to_string());
 
-                    if remaining > 0 {
-                        return Err(ModmailError::Command(CommandError::ClosureAlreadyScheduled));
-                    }
+                if remaining > 0 {
+                    return Err(ModmailError::Command(CommandError::ClosureAlreadyScheduled));
                 }
             }
 
@@ -350,34 +350,34 @@ impl RegistrableCommand for CloseCommand {
             .await?;
             let _ = delete_scheduled_closure(&thread.id, db_pool).await;
 
-            if config.bot.enable_rustmail_logs {
-                if let Some(logs_channel_id) = config.bot.logs_channel_id {
-                    let base_url = config
-                        .bot
-                        .redirect_url
-                        .trim_end_matches("/api/auth/callback")
-                        .trim_end_matches('/');
+            if config.bot.enable_rustmail_logs
+                && let Some(logs_channel_id) = config.bot.logs_channel_id
+            {
+                let base_url = config
+                    .bot
+                    .redirect_url
+                    .trim_end_matches("/api/auth/callback")
+                    .trim_end_matches('/');
 
-                    let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
+                let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
 
-                    let mut params = HashMap::new();
-                    params.insert("staff".to_string(), command.user.id.to_string());
-                    params.insert("username".to_string(), thread.user_name.clone());
-                    params.insert("user_id".to_string(), thread.user_id.to_string());
-                    params.insert("panel_url".to_string(), panel_url);
+                let mut params = HashMap::new();
+                params.insert("staff".to_string(), command.user.id.to_string());
+                params.insert("username".to_string(), thread.user_name.clone());
+                params.insert("user_id".to_string(), thread.user_id.to_string());
+                params.insert("panel_url".to_string(), panel_url);
 
-                    let _ = MessageBuilder::system_message(&ctx, &config)
-                        .translated_content(
-                            "logs.ticket_closed",
-                            Some(&params),
-                            Some(command.user.id),
-                            command.guild_id.map(|g| g.get()),
-                        )
-                        .await
-                        .to_channel(serenity::all::ChannelId::new(logs_channel_id))
-                        .send(true)
-                        .await;
-                }
+                let _ = MessageBuilder::system_message(&ctx, &config)
+                    .translated_content(
+                        "logs.ticket_closed",
+                        Some(&params),
+                        Some(command.user.id),
+                        command.guild_id.map(|g| g.get()),
+                    )
+                    .await
+                    .to_channel(serenity::all::ChannelId::new(logs_channel_id))
+                    .send(true)
+                    .await;
             }
 
             let _ = command.channel_id.delete(&ctx.http).await?;

--- a/crates/rustmail/src/commands/close/text_command/close.rs
+++ b/crates/rustmail/src/commands/close/text_command/close.rs
@@ -102,27 +102,27 @@ pub async fn close(
         return Ok(());
     }
 
-    if duration.is_none() {
-        if let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await {
-            let remaining = existing.close_at - Utc::now().timestamp();
+    if duration.is_none()
+        && let Ok(Some(existing)) = get_scheduled_closure(&thread.id, db_pool).await
+    {
+        let remaining = existing.close_at - Utc::now().timestamp();
 
-            let mut params = HashMap::new();
-            params.insert("seconds".to_string(), remaining.to_string());
+        let mut params = HashMap::new();
+        params.insert("seconds".to_string(), remaining.to_string());
 
-            if remaining > 0 {
-                let _ = MessageBuilder::system_message(&ctx, config)
-                    .translated_content(
-                        "close.closure_already_scheduled",
-                        Some(&params),
-                        Some(msg.author.id),
-                        msg.guild_id.map(|g| g.get()),
-                    )
-                    .await
-                    .to_channel(msg.channel_id)
-                    .send(true)
-                    .await;
-                return Ok(());
-            }
+        if remaining > 0 {
+            let _ = MessageBuilder::system_message(&ctx, config)
+                .translated_content(
+                    "close.closure_already_scheduled",
+                    Some(&params),
+                    Some(msg.author.id),
+                    msg.guild_id.map(|g| g.get()),
+                )
+                .await
+                .to_channel(msg.channel_id)
+                .send(true)
+                .await;
+            return Ok(());
         }
     }
 
@@ -290,34 +290,34 @@ pub async fn close(
     .await?;
     let _ = delete_scheduled_closure(&thread.id, db_pool).await;
 
-    if config.bot.enable_rustmail_logs {
-        if let Some(logs_channel_id) = config.bot.logs_channel_id {
-            let base_url = config
-                .bot
-                .redirect_url
-                .trim_end_matches("/api/auth/callback")
-                .trim_end_matches('/');
+    if config.bot.enable_rustmail_logs
+        && let Some(logs_channel_id) = config.bot.logs_channel_id
+    {
+        let base_url = config
+            .bot
+            .redirect_url
+            .trim_end_matches("/api/auth/callback")
+            .trim_end_matches('/');
 
-            let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
+        let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
 
-            let mut params = HashMap::new();
-            params.insert("staff".to_string(), msg.author.id.to_string());
-            params.insert("username".to_string(), thread.user_name.clone());
-            params.insert("user_id".to_string(), thread.user_id.to_string());
-            params.insert("panel_url".to_string(), panel_url);
+        let mut params = HashMap::new();
+        params.insert("staff".to_string(), msg.author.id.to_string());
+        params.insert("username".to_string(), thread.user_name.clone());
+        params.insert("user_id".to_string(), thread.user_id.to_string());
+        params.insert("panel_url".to_string(), panel_url);
 
-            let _ = MessageBuilder::system_message(&ctx, config)
-                .translated_content(
-                    "logs.ticket_closed",
-                    Some(&params),
-                    Some(msg.author.id),
-                    msg.guild_id.map(|g| g.get()),
-                )
-                .await
-                .to_channel(serenity::all::ChannelId::new(logs_channel_id))
-                .send(true)
-                .await;
-        }
+        let _ = MessageBuilder::system_message(&ctx, config)
+            .translated_content(
+                "logs.ticket_closed",
+                Some(&params),
+                Some(msg.author.id),
+                msg.guild_id.map(|g| g.get()),
+            )
+            .await
+            .to_channel(serenity::all::ChannelId::new(logs_channel_id))
+            .send(true)
+            .await;
     }
 
     let _ = msg.channel_id.delete(&ctx.http).await?;

--- a/crates/rustmail/src/commands/delete/common.rs
+++ b/crates/rustmail/src/commands/delete/common.rs
@@ -9,14 +9,14 @@ pub async fn get_thread_info(
     channel_id: &str,
     pool: &sqlx::SqlitePool,
 ) -> ModmailResult<(i64, Thread)> {
-    let user_id = match get_user_id_from_channel_id(&channel_id, pool).await {
+    let user_id = match get_user_id_from_channel_id(channel_id, pool).await {
         Some(uid) => uid,
         None => {
             return Err(validation_failed("Not in a thread"));
         }
     };
 
-    let thread = match get_thread_by_channel_id(&channel_id, pool).await {
+    let thread = match get_thread_by_channel_id(channel_id, pool).await {
         Some(thread) => thread,
         None => {
             return Err(validation_failed("Thread not found"));

--- a/crates/rustmail/src/commands/delete/slash_command/delete.rs
+++ b/crates/rustmail/src/commands/delete/slash_command/delete.rs
@@ -88,13 +88,10 @@ impl RegistrableCommand for DeleteCommand {
             let mut message_number: i64 = -1;
 
             for option in &command.data.options {
-                match option.name.as_str() {
-                    "message_id" => {
-                        if let CommandDataOptionValue::Number(val) = &option.value {
-                            message_number = *val as i64;
-                        }
-                    }
-                    _ => {}
+                if option.name.as_str() == "message_id"
+                    && let CommandDataOptionValue::Number(val) = &option.value
+                {
+                    message_number = *val as i64;
                 }
             }
 

--- a/crates/rustmail/src/commands/edit/common.rs
+++ b/crates/rustmail/src/commands/edit/common.rs
@@ -36,6 +36,7 @@ mod tests {
                 client_secret: "secret".to_string(),
                 redirect_url: "http://localhost:3002/api/auth/callback".to_string(),
                 ip: Option::from("0.0.0.0".to_string()),
+                panel_port: 8080,
                 timezone: "Europe/Paris".to_string().parse().unwrap(),
                 panel_super_admin_roles: vec![],
                 panel_super_admin_users: vec![],

--- a/crates/rustmail/src/commands/edit/message_ops.rs
+++ b/crates/rustmail/src/commands/edit/message_ops.rs
@@ -48,10 +48,9 @@ pub async fn format_new_message<'a>(
         .0
         .map(|m| m.guild_id)
         .or_else(|| msg.1.map(|i| i.guild_id))
+        && let Some(gid) = raw_guild_id
     {
-        if let Some(gid) = raw_guild_id {
-            guild_id = gid;
-        }
+        guild_id = gid;
     }
 
     if let Some(raw_user) = msg

--- a/crates/rustmail/src/commands/force_close/slash_command/force_close.rs
+++ b/crates/rustmail/src/commands/force_close/slash_command/force_close.rs
@@ -93,38 +93,34 @@ impl RegistrableCommand for ForceCloseCommand {
                         return Err(ModmailError::Thread(ThreadError::UserStillInServer));
                     }
 
-                    if let Some(thread_info) = thread {
-                        if config.bot.enable_rustmail_logs {
-                            if let Some(logs_channel_id) = config.bot.logs_channel_id {
-                                let base_url = config
-                                    .bot
-                                    .redirect_url
-                                    .trim_end_matches("/api/auth/callback")
-                                    .trim_end_matches('/');
+                    if let Some(thread_info) = thread
+                        && config.bot.enable_rustmail_logs
+                        && let Some(logs_channel_id) = config.bot.logs_channel_id
+                    {
+                        let base_url = config
+                            .bot
+                            .redirect_url
+                            .trim_end_matches("/api/auth/callback")
+                            .trim_end_matches('/');
 
-                                let panel_url =
-                                    format!("{}/panel/tickets/{}", base_url, thread_info.id);
+                        let panel_url = format!("{}/panel/tickets/{}", base_url, thread_info.id);
 
-                                let mut params = std::collections::HashMap::new();
-                                params
-                                    .insert("username".to_string(), thread_info.user_name.clone());
-                                params
-                                    .insert("user_id".to_string(), thread_info.user_id.to_string());
-                                params.insert("panel_url".to_string(), panel_url);
+                        let mut params = std::collections::HashMap::new();
+                        params.insert("username".to_string(), thread_info.user_name.clone());
+                        params.insert("user_id".to_string(), thread_info.user_id.to_string());
+                        params.insert("panel_url".to_string(), panel_url);
 
-                                let _ = MessageBuilder::system_message(&ctx, &config)
-                                    .translated_content(
-                                        "logs.ticket_closed",
-                                        Some(&params),
-                                        Some(command.user.id),
-                                        command.guild_id.map(|g| g.get()),
-                                    )
-                                    .await
-                                    .to_channel(serenity::all::ChannelId::new(logs_channel_id))
-                                    .send_interaction_followup(&command, true)
-                                    .await;
-                            }
-                        }
+                        let _ = MessageBuilder::system_message(&ctx, &config)
+                            .translated_content(
+                                "logs.ticket_closed",
+                                Some(&params),
+                                Some(command.user.id),
+                                command.guild_id.map(|g| g.get()),
+                            )
+                            .await
+                            .to_channel(serenity::all::ChannelId::new(logs_channel_id))
+                            .send_interaction_followup(&command, true)
+                            .await;
                     }
 
                     delete_channel(&ctx, command.channel_id).await

--- a/crates/rustmail/src/commands/force_close/text_command/force_close.rs
+++ b/crates/rustmail/src/commands/force_close/text_command/force_close.rs
@@ -35,35 +35,34 @@ pub async fn force_close(
                 return Err(ModmailError::Thread(ThreadError::UserStillInServer));
             }
 
-            if let Some(thread_info) = thread {
-                if config.bot.enable_rustmail_logs {
-                    if let Some(logs_channel_id) = config.bot.logs_channel_id {
-                        let base_url = config
-                            .bot
-                            .redirect_url
-                            .trim_end_matches("/api/auth/callback")
-                            .trim_end_matches('/');
+            if let Some(thread_info) = thread
+                && config.bot.enable_rustmail_logs
+                && let Some(logs_channel_id) = config.bot.logs_channel_id
+            {
+                let base_url = config
+                    .bot
+                    .redirect_url
+                    .trim_end_matches("/api/auth/callback")
+                    .trim_end_matches('/');
 
-                        let panel_url = format!("{}/panel/tickets/{}", base_url, thread_info.id);
+                let panel_url = format!("{}/panel/tickets/{}", base_url, thread_info.id);
 
-                        let mut params = std::collections::HashMap::new();
-                        params.insert("username".to_string(), thread_info.user_name.clone());
-                        params.insert("user_id".to_string(), thread_info.user_id.to_string());
-                        params.insert("panel_url".to_string(), panel_url);
+                let mut params = std::collections::HashMap::new();
+                params.insert("username".to_string(), thread_info.user_name.clone());
+                params.insert("user_id".to_string(), thread_info.user_id.to_string());
+                params.insert("panel_url".to_string(), panel_url);
 
-                        let _ = MessageBuilder::system_message(&ctx, config)
-                            .translated_content(
-                                "logs.ticket_closed",
-                                Some(&params),
-                                Some(msg.author.id),
-                                msg.guild_id.map(|g| g.get()),
-                            )
-                            .await
-                            .to_channel(serenity::all::ChannelId::new(logs_channel_id))
-                            .send(true)
-                            .await;
-                    }
-                }
+                let _ = MessageBuilder::system_message(&ctx, config)
+                    .translated_content(
+                        "logs.ticket_closed",
+                        Some(&params),
+                        Some(msg.author.id),
+                        msg.guild_id.map(|g| g.get()),
+                    )
+                    .await
+                    .to_channel(serenity::all::ChannelId::new(logs_channel_id))
+                    .send(true)
+                    .await;
             }
 
             delete_channel(&ctx, msg.channel_id).await

--- a/crates/rustmail/src/commands/help/common.rs
+++ b/crates/rustmail/src/commands/help/common.rs
@@ -15,15 +15,15 @@ pub async fn display_commands_list(
 ) -> ModmailResult<()> {
     let mut docs_message = String::new();
 
-    let welcome_msg = get_translated_message(&config, "help.message", None, None, None, None).await;
+    let welcome_msg = get_translated_message(config, "help.message", None, None, None, None).await;
     docs_message.push_str(&welcome_msg);
 
-    for (name, _) in &registry.commands {
+    for name in registry.commands.keys() {
         docs_message.push_str(&format!("- **{}**\n", name))
     }
 
     if let Some(msg) = msg {
-        let _ = MessageBuilder::system_message(&ctx, config)
+        let _ = MessageBuilder::system_message(ctx, config)
             .content(docs_message)
             .to_channel(msg.channel_id)
             .send(true)
@@ -33,10 +33,10 @@ pub async fn display_commands_list(
     }
 
     if let Some(command) = command {
-        let _ = MessageBuilder::system_message(&ctx, config)
+        let _ = MessageBuilder::system_message(ctx, config)
             .content(docs_message)
             .to_channel(command.channel_id)
-            .send_interaction_followup(&command, true)
+            .send_interaction_followup(command, true)
             .await;
 
         return Ok(());
@@ -61,7 +61,7 @@ pub async fn display_command_help(
         docs_message.push_str(&command_doc);
 
         if let Some(msg) = msg {
-            let _ = MessageBuilder::system_message(&ctx, config)
+            let _ = MessageBuilder::system_message(ctx, config)
                 .content(docs_message)
                 .to_channel(msg.channel_id)
                 .send(true)
@@ -71,10 +71,10 @@ pub async fn display_command_help(
         }
 
         if let Some(command) = command {
-            let _ = MessageBuilder::system_message(&ctx, config)
+            let _ = MessageBuilder::system_message(ctx, config)
                 .content(docs_message)
                 .to_channel(command.channel_id)
-                .send_interaction_followup(&command, true)
+                .send_interaction_followup(command, true)
                 .await;
 
             return Ok(());
@@ -84,7 +84,7 @@ pub async fn display_command_help(
         Ok(())
     } else {
         Err(ModmailError::Command(CommandError::UnknownCommand(
-            format!("{}", command_name),
+            command_name.to_string(),
         )))
     }
 }

--- a/crates/rustmail/src/commands/help/slash_command/help.rs
+++ b/crates/rustmail/src/commands/help/slash_command/help.rs
@@ -74,13 +74,10 @@ impl RegistrableCommand for HelpCommand {
             let mut command_name: Option<String> = None;
 
             for option in &command.data.options {
-                match option.name.as_str() {
-                    "command" => {
-                        if let CommandDataOptionValue::String(val) = &option.value {
-                            command_name.replace(val.clone());
-                        }
-                    }
-                    _ => {}
+                if option.name.as_str() == "command"
+                    && let CommandDataOptionValue::String(val) = &option.value
+                {
+                    command_name.replace(val.clone());
                 }
             }
 

--- a/crates/rustmail/src/commands/help/text_command/help.rs
+++ b/crates/rustmail/src/commands/help/text_command/help.rs
@@ -6,7 +6,7 @@ use serenity::all::{Context, Message};
 use std::sync::Arc;
 
 fn extract_request_command_name(command: &str) -> &str {
-    let parts: Vec<&str> = command.trim().split_whitespace().collect();
+    let parts: Vec<&str> = command.split_whitespace().collect();
     if parts.len() > 1 { parts[1] } else { "" }
 }
 

--- a/crates/rustmail/src/commands/id/slash_command/id.rs
+++ b/crates/rustmail/src/commands/id/slash_command/id.rs
@@ -77,10 +77,7 @@ impl RegistrableCommand for IdCommand {
 
             let mut params = std::collections::HashMap::new();
             params.insert("user".to_string(), format!("<@{}>", thread.user_id));
-            params.insert(
-                "id".to_string(),
-                format!("||{}||", thread.user_id.to_string()),
-            );
+            params.insert("id".to_string(), format!("||{}||", thread.user_id));
 
             let _ = MessageBuilder::system_message(&ctx, &config)
                 .translated_content("id.show_id", Some(&params), None, None)

--- a/crates/rustmail/src/commands/id/text_command/id.rs
+++ b/crates/rustmail/src/commands/id/text_command/id.rs
@@ -17,7 +17,7 @@ pub async fn id(
         .as_ref()
         .ok_or_else(database_connection_failed)?;
 
-    if is_a_ticket_channel(msg.channel_id, &db_pool).await {
+    if is_a_ticket_channel(msg.channel_id, db_pool).await {
         let thread = match get_thread_by_channel_id(&msg.channel_id.to_string(), db_pool).await {
             Some(thread) => thread,
             None => return Err(thread_not_found()),
@@ -25,10 +25,7 @@ pub async fn id(
 
         let mut params = std::collections::HashMap::new();
         params.insert("user".to_string(), format!("<@{}>", thread.user_id));
-        params.insert(
-            "id".to_string(),
-            format!("||{}||", thread.user_id.to_string()),
-        );
+        params.insert("id".to_string(), format!("||{}||", thread.user_id));
 
         let _ = MessageBuilder::system_message(&ctx, config)
             .translated_content("id.show_id", Some(&params), None, None)

--- a/crates/rustmail/src/commands/logs/common.rs
+++ b/crates/rustmail/src/commands/logs/common.rs
@@ -26,7 +26,7 @@ pub async fn render_logs_page(
     page: usize,
     per_page: usize,
 ) -> String {
-    let total_pages = (logs.len() + per_page - 1) / per_page;
+    let total_pages = logs.len().div_ceil(per_page);
     let start = page * per_page;
     let end = usize::min(start + per_page, logs.len());
     let no_logs = get_translated_message(
@@ -45,11 +45,11 @@ pub async fn render_logs_page(
         return no_logs;
     }
 
-    for (_, log) in logs[start..end].iter().enumerate() {
+    for log in logs[start..end].iter() {
         use std::fmt::Write;
         let _ = writeln!(
             desc,
-            "**#{}** | [`🎫 {}`]({}) | 🔒 {} {}",
+            "**#{}** | [`🎫 {}`]({}) | 🔒 {} \n",
             log.id,
             log.ticket_id,
             format!(
@@ -58,7 +58,6 @@ pub async fn render_logs_page(
                 log.ticket_id
             ),
             log.created_at,
-            "\n".to_string(),
         );
     }
 
@@ -83,7 +82,7 @@ pub async fn get_response(
     channel_id: ChannelId,
     command: Option<CommandInteraction>,
 ) -> Result<Message, ModmailError> {
-    if !command.is_none() {
+    if command.is_some() {
         let command = command.unwrap();
 
         MessageBuilder::system_message(&ctx.clone(), &config.clone())

--- a/crates/rustmail/src/commands/logs/common.rs
+++ b/crates/rustmail/src/commands/logs/common.rs
@@ -49,7 +49,7 @@ pub async fn render_logs_page(
         use std::fmt::Write;
         let _ = writeln!(
             desc,
-            "**#{}** | [`🎫 {}`]({}) | 🔒 {} \n",
+            "**#{}** | [`🎫 {}`]({}) | 🔒 {}",
             log.id,
             log.ticket_id,
             format!(

--- a/crates/rustmail/src/commands/logs/slash_command/logs.rs
+++ b/crates/rustmail/src/commands/logs/slash_command/logs.rs
@@ -75,17 +75,14 @@ impl RegistrableCommand for LogsCommand {
             let mut user_id: Option<UserId> = None;
 
             for option in &command.data.options {
-                match option.name.as_str() {
-                    "id" => {
-                        if let CommandDataOptionValue::User(val) = &option.value {
-                            user_id.replace(val.clone());
-                        }
+                if option.name.as_str() == "id" {
+                    if let CommandDataOptionValue::User(val) = &option.value {
+                        user_id.replace(*val);
                     }
-                    _ => {}
                 }
             }
 
-            if !user_id.is_some() {
+            if user_id.is_none() {
                 handle_logs_in_thread(
                     &ctx,
                     &command.clone().channel_id,

--- a/crates/rustmail/src/commands/logs/text_command/logs.rs
+++ b/crates/rustmail/src/commands/logs/text_command/logs.rs
@@ -20,17 +20,17 @@ pub async fn handle_logs_in_thread(
     pool: &SqlitePool,
     pagination: PaginationStore,
 ) -> ModmailResult<()> {
-    let thread = match get_thread_by_channel_id(&channel_id.to_string(), &pool).await {
+    let thread = match get_thread_by_channel_id(&channel_id.to_string(), pool).await {
         Some(thread) => thread,
         None => return Err(ModmailError::Thread(ThreadError::ThreadNotFound)),
     };
 
     handle_logs_from_user_id(
-        &ctx,
+        ctx,
         channel_id,
         command,
-        &config,
-        &pool,
+        config,
+        pool,
         &thread.user_id.to_string(),
         pagination,
     )
@@ -46,7 +46,7 @@ pub async fn handle_logs_from_user_id(
     user_id: &str,
     pagination_store: PaginationStore,
 ) -> ModmailResult<()> {
-    let logs = match get_logs_from_user_id(&user_id, &pool).await {
+    let logs = match get_logs_from_user_id(user_id, pool).await {
         Ok(logs) => logs,
         Err(e) => {
             eprintln!("Error retrieving logs for user ID {}: {:?}", user_id, e);
@@ -61,9 +61,9 @@ pub async fn handle_logs_from_user_id(
     let session_id = Uuid::new_v4().to_string();
 
     let next_button =
-        get_translated_message(&config, "logs_command.next", None, None, None, None).await;
+        get_translated_message(config, "logs_command.next", None, None, None, None).await;
     let prev_button =
-        get_translated_message(&config, "logs_command.prev", None, None, None, None).await;
+        get_translated_message(config, "logs_command.prev", None, None, None, None).await;
 
     let components = make_buttons(&[
         (
@@ -114,14 +114,14 @@ pub async fn logs(
         None => return Err(ModmailError::Database(DatabaseError::ConnectionFailed)),
     };
 
-    let user_id = extract_user_id_for_logs(&msg, &config);
+    let user_id = extract_user_id_for_logs(&msg, config);
 
     if user_id.is_empty() {
         handle_logs_in_thread(
             &ctx,
             &msg.channel_id,
             None,
-            &config,
+            config,
             &pool,
             handler.pagination.clone(),
         )

--- a/crates/rustmail/src/commands/move_thread/common.rs
+++ b/crates/rustmail/src/commands/move_thread/common.rs
@@ -49,8 +49,6 @@ pub async fn fetch_server_categories(ctx: &Context, config: &Config) -> Vec<(Cha
 
 fn map_move_error(err: serenity::Error) -> ModmailError {
     if let serenity::Error::Http(HttpError::UnsuccessfulRequest(ref resp)) = err {
-        // 30013 = "Maximum number of guild channels reached"
-        // 30030 = "Maximum number of server categories reached"
         if resp.error.code == 30013 || resp.error.code == 30030 {
             return ModmailError::Discord(DiscordError::CategoryFull);
         }

--- a/crates/rustmail/src/commands/move_thread/slash_command/move_thread.rs
+++ b/crates/rustmail/src/commands/move_thread/slash_command/move_thread.rs
@@ -84,9 +84,9 @@ impl RegistrableCommand for MoveCommand {
 
             defer_response(&ctx, &command).await?;
 
-            if !get_user_id_from_channel_id(&command.channel_id.to_string(), pool)
+            if get_user_id_from_channel_id(&command.channel_id.to_string(), pool)
                 .await
-                .is_some()
+                .is_none()
             {
                 return Err(ModmailError::Command(CommandError::NotInThread()));
             }

--- a/crates/rustmail/src/commands/new_thread/slash_command/new_thread.rs
+++ b/crates/rustmail/src/commands/new_thread/slash_command/new_thread.rs
@@ -219,8 +219,7 @@ impl RegistrableCommand for NewThreadCommand {
 
             println!(
                 "Thread created for user {} in channel {}",
-                user.name,
-                guild_channel.to_string()
+                user.name, guild_channel
             );
 
             let _ = MessageBuilder::system_message(&ctx, &config)

--- a/crates/rustmail/src/commands/new_thread/text_command/new_thread.rs
+++ b/crates/rustmail/src/commands/new_thread/text_command/new_thread.rs
@@ -103,7 +103,7 @@ pub async fn new_thread(
     };
 
     let logs_info = get_translated_message(
-        &config,
+        config,
         "new_thread.show_logs",
         Some(&params),
         None,
@@ -114,7 +114,7 @@ pub async fn new_thread(
 
     let recap = get_user_recap(user_id, &user.name, &member_join_date, &logs_info);
 
-    let _ = MessageBuilder::system_message(&ctx, &config)
+    let _ = MessageBuilder::system_message(&ctx, config)
         .content(recap)
         .to_channel(guild_channel.id)
         .send(true)

--- a/crates/rustmail/src/commands/ping/text_command/ping.rs
+++ b/crates/rustmail/src/commands/ping/text_command/ping.rs
@@ -53,7 +53,7 @@ pub async fn ping(
         format!("{:?}", msg_send_ping),
     );
 
-    let edited_msg = MessageBuilder::system_message(&ctx, &config)
+    let edited_msg = MessageBuilder::system_message(&ctx, config)
         .translated_content("slash_command.ping_command", Some(&params), None, None)
         .await
         .to_channel(msg.channel_id)

--- a/crates/rustmail/src/commands/release/slash_command/release.rs
+++ b/crates/rustmail/src/commands/release/slash_command/release.rs
@@ -61,7 +61,7 @@ impl RegistrableCommand for ReleaseCommand {
 
             defer_response(&ctx, &command).await?;
 
-            if is_a_ticket_channel(command.channel_id, &db_pool).await {
+            if is_a_ticket_channel(command.channel_id, db_pool).await {
                 let thread = match get_thread_by_channel_id(
                     &command.channel_id.to_string(),
                     db_pool,

--- a/crates/rustmail/src/commands/release/text_command/release.rs
+++ b/crates/rustmail/src/commands/release/text_command/release.rs
@@ -18,7 +18,7 @@ pub async fn release(
         .as_ref()
         .ok_or_else(database_connection_failed)?;
 
-    if is_a_ticket_channel(msg.channel_id, &db_pool).await {
+    if is_a_ticket_channel(msg.channel_id, db_pool).await {
         let thread = match get_thread_by_channel_id(&msg.channel_id.to_string(), db_pool).await {
             Some(thread) => thread,
             None => return Err(thread_not_found()),

--- a/crates/rustmail/src/commands/reminder_subscription/slash_command/reminder_subscription.rs
+++ b/crates/rustmail/src/commands/reminder_subscription/slash_command/reminder_subscription.rs
@@ -118,11 +118,9 @@ impl RegistrableCommand for ReminderSubscriptionCommand {
                 }
             }
 
-            let action =
-                action.ok_or_else(|| ModmailError::Command(CommandError::MissingArguments))?;
+            let action = action.ok_or(ModmailError::Command(CommandError::MissingArguments))?;
 
-            let role_id =
-                role_id.ok_or_else(|| ModmailError::Command(CommandError::MissingArguments))?;
+            let role_id = role_id.ok_or(ModmailError::Command(CommandError::MissingArguments))?;
 
             let is_subscribe = action == "subscribe";
 

--- a/crates/rustmail/src/commands/remove_reminder/slash_command/remove_reminder.rs
+++ b/crates/rustmail/src/commands/remove_reminder/slash_command/remove_reminder.rs
@@ -80,13 +80,10 @@ impl RegistrableCommand for RemoveReminderCommand {
             let mut reminder_id: Option<i64> = None;
 
             for option in &command.data.options {
-                match option.name.as_str() {
-                    "id" => {
-                        if let CommandDataOptionValue::Number(val) = &option.value {
-                            reminder_id.replace(*val as i64);
-                        }
-                    }
-                    _ => {}
+                if option.name.as_str() == "id"
+                    && let CommandDataOptionValue::Number(val) = &option.value
+                {
+                    reminder_id.replace(*val as i64);
                 }
             }
 

--- a/crates/rustmail/src/commands/remove_reminder/text_command/remove_reminder.rs
+++ b/crates/rustmail/src/commands/remove_reminder/text_command/remove_reminder.rs
@@ -64,7 +64,7 @@ pub async fn remove_reminder(
             let mut params = HashMap::new();
             params.insert("id".to_string(), reminder_id.to_string());
 
-            let _ = MessageBuilder::system_message(&ctx, &config)
+            let _ = MessageBuilder::system_message(&ctx, config)
                 .translated_content("remove_reminder.confirmation", Some(&params), None, None)
                 .await
                 .to_channel(msg.channel_id)

--- a/crates/rustmail/src/commands/remove_staff/text_command/remove_staff.rs
+++ b/crates/rustmail/src/commands/remove_staff/text_command/remove_staff.rs
@@ -30,7 +30,7 @@ pub async fn remove_staff(
     }
 
     let parsed =
-        parse_add_target(&raw).ok_or_else(|| ModmailError::Command(CommandError::InvalidFormat))?;
+        parse_add_target(&raw).ok_or(ModmailError::Command(CommandError::InvalidFormat))?;
 
     let guild_id = msg
         .guild_id

--- a/crates/rustmail/src/commands/rename/slash_command/rename.rs
+++ b/crates/rustmail/src/commands/rename/slash_command/rename.rs
@@ -81,7 +81,7 @@ impl RegistrableCommand for RenameCommand {
 
             defer_response(&ctx, &command).await?;
 
-            if !is_a_ticket_channel(command.channel_id, &db_pool).await {
+            if !is_a_ticket_channel(command.channel_id, db_pool).await {
                 return Err(ModmailError::Thread(ThreadError::NotAThreadChannel));
             }
 
@@ -93,12 +93,11 @@ impl RegistrableCommand for RenameCommand {
 
             let mut new_label: Option<String> = None;
             for option in &command.data.options {
-                if option.name.as_str() == "label" {
-                    if let CommandDataOptionValue::String(val) = &option.value {
-                        if !val.trim().is_empty() {
-                            new_label = Some(val.trim().to_string());
-                        }
-                    }
+                if option.name.as_str() == "label"
+                    && let CommandDataOptionValue::String(val) = &option.value
+                    && !val.trim().is_empty()
+                {
+                    new_label = Some(val.trim().to_string());
                 }
             }
 

--- a/crates/rustmail/src/commands/rename/text_command/rename.rs
+++ b/crates/rustmail/src/commands/rename/text_command/rename.rs
@@ -18,7 +18,7 @@ pub async fn rename_ticket(
         .as_ref()
         .ok_or_else(database_connection_failed)?;
 
-    if !is_a_ticket_channel(msg.channel_id, &db_pool).await {
+    if !is_a_ticket_channel(msg.channel_id, db_pool).await {
         return Err(ModmailError::Thread(ThreadError::NotAThreadChannel));
     }
 

--- a/crates/rustmail/src/commands/reply/text_command/reply.rs
+++ b/crates/rustmail/src/commands/reply/text_command/reply.rs
@@ -22,18 +22,18 @@ pub async fn reply(
 
     let mut content = extract_reply_content(&msg.content, &config.command.prefix, &["reply", "r"]);
 
-    if let Some(text) = &content {
-        if let Some(stripped) = text.strip_prefix("{{").and_then(|s| s.strip_suffix("}}")) {
-            let snippet_key = stripped.trim();
-            match get_snippet_by_key(snippet_key, db_pool).await? {
-                Some(snippet) => {
-                    content = Some(snippet.content);
-                }
-                None => {
-                    return Err(ModmailError::Command(CommandError::SnippetNotFound(
-                        snippet_key.to_string(),
-                    )));
-                }
+    if let Some(text) = &content
+        && let Some(stripped) = text.strip_prefix("{{").and_then(|s| s.strip_suffix("}}"))
+    {
+        let snippet_key = stripped.trim();
+        match get_snippet_by_key(snippet_key, db_pool).await? {
+            Some(snippet) => {
+                content = Some(snippet.content);
+            }
+            None => {
+                return Err(ModmailError::Command(CommandError::SnippetNotFound(
+                    snippet_key.to_string(),
+                )));
             }
         }
     }

--- a/crates/rustmail/src/commands/snippet/slash_command/snippet.rs
+++ b/crates/rustmail/src/commands/snippet/slash_command/snippet.rs
@@ -278,22 +278,22 @@ async fn handle_create(
     let mut key = String::new();
     let mut content = String::new();
 
-    if let Some(subcommand) = options.first() {
-        if let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value {
-            for option in sub_options {
-                match option.name.as_str() {
-                    "key" => {
-                        if let CommandDataOptionValue::String(val) = &option.value {
-                            key = val.to_string();
-                        }
+    if let Some(subcommand) = options.first()
+        && let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value
+    {
+        for option in sub_options {
+            match option.name.as_str() {
+                "key" => {
+                    if let CommandDataOptionValue::String(val) = &option.value {
+                        key = val.to_string();
                     }
-                    "content" => {
-                        if let CommandDataOptionValue::String(val) = &option.value {
-                            content = val.to_string();
-                        }
-                    }
-                    _ => {}
                 }
+                "content" => {
+                    if let CommandDataOptionValue::String(val) = &option.value {
+                        content = val.to_string();
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -329,7 +329,7 @@ async fn handle_create(
         )
         .await
         .to_channel(command.channel_id)
-        .send_interaction_followup(&command, false)
+        .send_interaction_followup(command, false)
         .await;
 
     Ok(())
@@ -353,7 +353,7 @@ async fn handle_list(
             )
             .await
             .to_channel(command.channel_id)
-            .send_interaction_followup(&command, false)
+            .send_interaction_followup(command, false)
             .await;
 
         return Ok(());
@@ -377,7 +377,7 @@ async fn handle_list(
     let _ = MessageBuilder::system_message(ctx, config)
         .content(content)
         .to_channel(command.channel_id)
-        .send_interaction_followup(&command, true)
+        .send_interaction_followup(command, true)
         .await;
 
     Ok(())
@@ -392,14 +392,14 @@ async fn handle_show(
 ) -> ModmailResult<()> {
     let mut key = String::new();
 
-    if let Some(subcommand) = options.first() {
-        if let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value {
-            for option in sub_options {
-                if option.name == "key" {
-                    if let CommandDataOptionValue::String(val) = &option.value {
-                        key = val.to_string();
-                    }
-                }
+    if let Some(subcommand) = options.first()
+        && let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value
+    {
+        for option in sub_options {
+            if option.name == "key"
+                && let CommandDataOptionValue::String(val) = &option.value
+            {
+                key = val.to_string();
             }
         }
     }
@@ -449,7 +449,7 @@ async fn handle_show(
             let _ = MessageBuilder::system_message(ctx, config)
                 .content(content)
                 .to_channel(command.channel_id)
-                .send_interaction_followup(&command, true)
+                .send_interaction_followup(command, true)
                 .await;
         }
         None => {
@@ -472,22 +472,22 @@ async fn handle_edit(
     let mut key = String::new();
     let mut content = String::new();
 
-    if let Some(subcommand) = options.first() {
-        if let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value {
-            for option in sub_options {
-                match option.name.as_str() {
-                    "key" => {
-                        if let CommandDataOptionValue::String(val) = &option.value {
-                            key = val.to_string();
-                        }
+    if let Some(subcommand) = options.first()
+        && let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value
+    {
+        for option in sub_options {
+            match option.name.as_str() {
+                "key" => {
+                    if let CommandDataOptionValue::String(val) = &option.value {
+                        key = val.to_string();
                     }
-                    "content" => {
-                        if let CommandDataOptionValue::String(val) = &option.value {
-                            content = val.to_string();
-                        }
-                    }
-                    _ => {}
                 }
+                "content" => {
+                    if let CommandDataOptionValue::String(val) = &option.value {
+                        content = val.to_string();
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -517,7 +517,7 @@ async fn handle_edit(
         )
         .await
         .to_channel(command.channel_id)
-        .send_interaction_followup(&command, true)
+        .send_interaction_followup(command, true)
         .await;
 
     Ok(())
@@ -532,14 +532,14 @@ async fn handle_delete(
 ) -> ModmailResult<()> {
     let mut key = String::new();
 
-    if let Some(subcommand) = options.first() {
-        if let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value {
-            for option in sub_options {
-                if option.name == "key" {
-                    if let CommandDataOptionValue::String(val) = &option.value {
-                        key = val.to_string();
-                    }
-                }
+    if let Some(subcommand) = options.first()
+        && let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value
+    {
+        for option in sub_options {
+            if option.name == "key"
+                && let CommandDataOptionValue::String(val) = &option.value
+            {
+                key = val.to_string();
             }
         }
     }
@@ -565,7 +565,7 @@ async fn handle_delete(
         )
         .await
         .to_channel(command.channel_id)
-        .send_interaction_followup(&command, true)
+        .send_interaction_followup(command, true)
         .await;
 
     Ok(())
@@ -580,14 +580,14 @@ async fn handle_use(
 ) -> ModmailResult<()> {
     let mut key = String::new();
 
-    if let Some(subcommand) = options.first() {
-        if let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value {
-            for option in sub_options {
-                if option.name == "key" {
-                    if let CommandDataOptionValue::String(val) = &option.value {
-                        key = val.to_string();
-                    }
-                }
+    if let Some(subcommand) = options.first()
+        && let CommandDataOptionValue::SubCommand(sub_options) = &subcommand.value
+    {
+        for option in sub_options {
+            if option.name == "key"
+                && let CommandDataOptionValue::String(val) = &option.value
+            {
+                key = val.to_string();
             }
         }
     }
@@ -626,12 +626,12 @@ async fn handle_use(
                     )
                     .await
                     .ephemeral(true)
-                    .send_interaction_followup(&command, true)
+                    .send_interaction_followup(command, true)
                     .await;
             } else {
                 let _ = MessageBuilder::system_message(ctx, config)
                     .content(&snippet.content)
-                    .send_interaction_followup(&command, true)
+                    .send_interaction_followup(command, true)
                     .await;
             }
         }

--- a/crates/rustmail/src/commands/snippet/text_command/snippet.rs
+++ b/crates/rustmail/src/commands/snippet/text_command/snippet.rs
@@ -345,7 +345,7 @@ async fn handle_delete(
         return Ok(());
     }
 
-    match delete_snippet(&key, pool).await {
+    match delete_snippet(key, pool).await {
         Ok(_) => {}
         Err(_) => {
             return Err(ModmailError::Command(CommandError::SnippetNotFound(

--- a/crates/rustmail/src/commands/status/slash_command/status.rs
+++ b/crates/rustmail/src/commands/status/slash_command/status.rs
@@ -165,10 +165,10 @@ impl RegistrableCommand for StatusCommand {
             defer_response(&ctx, &command).await?;
 
             let mode = command.data.options.iter().find_map(|opt| {
-                if opt.name == "mode" {
-                    if let CommandDataOptionValue::String(s) = &opt.value {
-                        return Some(s.clone());
-                    }
+                if opt.name == "mode"
+                    && let CommandDataOptionValue::String(s) = &opt.value
+                {
+                    return Some(s.clone());
                 }
                 None
             });

--- a/crates/rustmail/src/commands/take/slash_command/take.rs
+++ b/crates/rustmail/src/commands/take/slash_command/take.rs
@@ -61,7 +61,7 @@ impl RegistrableCommand for TakeCommand {
 
             defer_response(&ctx, &command).await?;
 
-            if is_a_ticket_channel(command.channel_id, &db_pool).await {
+            if is_a_ticket_channel(command.channel_id, db_pool).await {
                 let thread = match get_thread_by_channel_id(
                     &command.channel_id.to_string(),
                     db_pool,

--- a/crates/rustmail/src/commands/take/text_command/take.rs
+++ b/crates/rustmail/src/commands/take/text_command/take.rs
@@ -18,7 +18,7 @@ pub async fn take(
         .as_ref()
         .ok_or_else(database_connection_failed)?;
 
-    if is_a_ticket_channel(msg.channel_id, &db_pool).await {
+    if is_a_ticket_channel(msg.channel_id, db_pool).await {
         let thread = match get_thread_by_channel_id(&msg.channel_id.to_string(), db_pool).await {
             Some(thread) => thread,
             None => return Err(thread_not_found()),

--- a/crates/rustmail/src/config.rs
+++ b/crates/rustmail/src/config.rs
@@ -31,19 +31,62 @@ fn get_local_ip() -> Option<String> {
     Some(socket.local_addr().ok()?.ip().to_string())
 }
 
+pub fn resolve_config_path(default: &str) -> String {
+    std::env::var("RUSTMAIL_CONFIG_PATH").unwrap_or_else(|_| default.to_string())
+}
+
+pub fn resolve_db_path(default: &str) -> String {
+    std::env::var("RUSTMAIL_DATABASE_URL")
+        .or_else(|_| std::env::var("RUSTMAIL_DB_PATH"))
+        .unwrap_or_else(|_| default.to_string())
+}
+
+pub fn resolve_bind_address(default: &str) -> String {
+    std::env::var("RUSTMAIL_BIND_ADDRESS").unwrap_or_else(|_| default.to_string())
+}
+
+pub fn resolve_port(default: u16) -> u16 {
+    std::env::var("RUSTMAIL_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(default)
+}
+
+fn apply_env_overrides(config: &mut ConfigResponse) {
+    if let Ok(token) = std::env::var("RUSTMAIL_BOT_TOKEN") {
+        if !token.is_empty() {
+            config.bot.token = token;
+        }
+    }
+
+    if let Ok(client_secret) = std::env::var("RUSTMAIL_BOT_CLIENT_SECRET") {
+        if !client_secret.is_empty() {
+            config.bot.client_secret = client_secret;
+        }
+    }
+
+    if let Ok(client_id) = std::env::var("RUSTMAIL_BOT_CLIENT_ID") {
+        if let Ok(id) = client_id.parse::<u64>() {
+            config.bot.client_id = id;
+        }
+    }
+}
+
 pub fn load_config(path: &str) -> Option<Config> {
     let content = match fs::read_to_string(path) {
         Ok(c) => c,
         Err(_) => return None,
     };
 
-    let config_response: ConfigResponse = match toml::from_str(&content) {
+    let mut config_response: ConfigResponse = match toml::from_str(&content) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("Failed to parse config.toml: {}", e);
             return None;
         }
     };
+
+    apply_env_overrides(&mut config_response);
 
     let mut bot = config_response.bot;
     if bot.ip.is_none() {
@@ -108,6 +151,60 @@ pub fn load_config(path: &str) -> Option<Config> {
         error_handler: Some(error_handler),
         thread_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     })
+}
+
+pub fn validate_config(config: &Config) -> Result<(), String> {
+    if u64::from_str_radix(&config.thread.user_message_color, 16).is_err() {
+        return Err("Invalid user message color format (must be hex)".to_string());
+    }
+
+    if u64::from_str_radix(&config.thread.staff_message_color, 16).is_err() {
+        return Err("Invalid staff message color format (must be hex)".to_string());
+    }
+
+    if u64::from_str_radix(&config.reminders.embed_color, 16).is_err() {
+        return Err("Invalid reminder embed color format (must be hex)".to_string());
+    }
+
+    config.bot.validate_logs_config()?;
+    config.bot.validate_features_config()?;
+
+    if !config
+        .language
+        .is_language_supported(config.language.get_default_language())
+    {
+        return Err(format!(
+            "Default language '{}' is not in supported languages list",
+            config.language.default_language
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn save_config_with_backup(config: &Config, path: &str) -> Result<(), String> {
+    if std::path::Path::new(path).exists() {
+        let backup_path = format!("{}.backup", path);
+        fs::copy(path, &backup_path).map_err(|e| format!("Failed to create backup: {}", e))?;
+    }
+
+    let config_response = ConfigResponse {
+        bot: config.bot.clone(),
+        command: config.command.clone(),
+        thread: config.thread.clone(),
+        language: config.language.clone(),
+        error_handling: config.error_handling.clone(),
+        notifications: config.notifications.clone(),
+        reminders: config.reminders.clone(),
+        logs: config.logs.clone(),
+    };
+
+    let toml_content = toml::to_string_pretty(&config_response)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
+
+    fs::write(path, toml_content).map_err(|e| format!("Failed to write config file: {}", e))?;
+
+    Ok(())
 }
 
 pub trait LanguageConfigExt {

--- a/crates/rustmail/src/config.rs
+++ b/crates/rustmail/src/config.rs
@@ -53,22 +53,22 @@ pub fn resolve_port(default: u16) -> u16 {
 }
 
 fn apply_env_overrides(config: &mut ConfigResponse) {
-    if let Ok(token) = std::env::var("RUSTMAIL_BOT_TOKEN") {
-        if !token.is_empty() {
-            config.bot.token = token;
-        }
+    if let Ok(token) = std::env::var("RUSTMAIL_BOT_TOKEN")
+        && !token.is_empty()
+    {
+        config.bot.token = token;
     }
 
-    if let Ok(client_secret) = std::env::var("RUSTMAIL_BOT_CLIENT_SECRET") {
-        if !client_secret.is_empty() {
-            config.bot.client_secret = client_secret;
-        }
+    if let Ok(client_secret) = std::env::var("RUSTMAIL_BOT_CLIENT_SECRET")
+        && !client_secret.is_empty()
+    {
+        config.bot.client_secret = client_secret;
     }
 
-    if let Ok(client_id) = std::env::var("RUSTMAIL_BOT_CLIENT_ID") {
-        if let Ok(id) = client_id.parse::<u64>() {
-            config.bot.client_id = id;
-        }
+    if let Ok(client_id) = std::env::var("RUSTMAIL_BOT_CLIENT_ID")
+        && let Ok(id) = client_id.parse::<u64>()
+    {
+        config.bot.client_id = id;
     }
 }
 

--- a/crates/rustmail/src/db/operations/banned_users.rs
+++ b/crates/rustmail/src/db/operations/banned_users.rs
@@ -89,7 +89,6 @@ pub async fn bulk_upsert_tracked_members(
         return Ok(());
     }
 
-    // Pre-serialize all roles to JSON up front so errors surface before the transaction opens.
     let roles_jsons: Vec<String> = members
         .iter()
         .map(|m| {
@@ -98,9 +97,6 @@ pub async fn bulk_upsert_tracked_members(
         })
         .collect::<ModmailResult<Vec<_>>>()?;
 
-    // Pair each member with its serialized roles, then chunk. SQLite's default
-    // SQLITE_MAX_VARIABLE_NUMBER is 999; with 10 bind parameters per row we stay
-    // safely under that limit by capping each statement at 99 rows.
     let pairs: Vec<(&TrackedMember, &String)> = members.iter().zip(roles_jsons.iter()).collect();
     const CHUNK_SIZE: usize = 99;
 

--- a/crates/rustmail/src/db/operations/init.rs
+++ b/crates/rustmail/src/db/operations/init.rs
@@ -1,3 +1,4 @@
+use crate::config::resolve_db_path;
 use sqlx::{
     SqlitePool,
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
@@ -8,12 +9,12 @@ use std::str::FromStr;
 use std::time::Duration;
 
 pub async fn init_database() -> Result<SqlitePool, sqlx::Error> {
-    let db_path = "db/db.sqlite";
+    let db_path = resolve_db_path("db/db.sqlite");
 
     fs::create_dir_all("db")?;
 
-    if !Path::new(db_path).exists() {
-        fs::File::create(db_path)?;
+    if !Path::new(&db_path).exists() {
+        fs::File::create(&db_path)?;
         println!("Database file created at: {}", db_path);
     }
 

--- a/crates/rustmail/src/db/operations/init.rs
+++ b/crates/rustmail/src/db/operations/init.rs
@@ -11,7 +11,11 @@ use std::time::Duration;
 pub async fn init_database() -> Result<SqlitePool, sqlx::Error> {
     let db_path = resolve_db_path("db/db.sqlite");
 
-    fs::create_dir_all("db")?;
+    if let Some(parent) = Path::new(&db_path).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
 
     if !Path::new(&db_path).exists() {
         fs::File::create(&db_path)?;

--- a/crates/rustmail/src/handlers/audit_log/formatters/member.rs
+++ b/crates/rustmail/src/handlers/audit_log/formatters/member.rs
@@ -53,29 +53,29 @@ impl AuditLogFormatter for MemberFormatter {
     async fn description(&self, alc: &AuditLogContext<'_>) -> String {
         match self.0 {
             MemberAction::MemberMove => {
-                if let Some(opts) = &alc.entry.options {
-                    if let Some(channel_id) = opts.channel_id {
-                        let mut params = HashMap::new();
-                        params.insert("channel".to_string(), format!("<#{}>", channel_id.get()));
-                        if let Some(count) = opts.count {
-                            params.insert("count".to_string(), count.to_string());
-                        }
-                        return alc
-                            .translate("audit_log.member.moved_to", Some(&params))
-                            .await;
+                if let Some(opts) = &alc.entry.options
+                    && let Some(channel_id) = opts.channel_id
+                {
+                    let mut params = HashMap::new();
+                    params.insert("channel".to_string(), format!("<#{}>", channel_id.get()));
+                    if let Some(count) = opts.count {
+                        params.insert("count".to_string(), count.to_string());
                     }
+                    return alc
+                        .translate("audit_log.member.moved_to", Some(&params))
+                        .await;
                 }
                 return String::new();
             }
             MemberAction::MemberDisconnect => {
-                if let Some(opts) = &alc.entry.options {
-                    if let Some(count) = opts.count {
-                        let mut params = HashMap::new();
-                        params.insert("count".to_string(), count.to_string());
-                        return alc
-                            .translate("audit_log.member.disconnected_count", Some(&params))
-                            .await;
-                    }
+                if let Some(opts) = &alc.entry.options
+                    && let Some(count) = opts.count
+                {
+                    let mut params = HashMap::new();
+                    params.insert("count".to_string(), count.to_string());
+                    return alc
+                        .translate("audit_log.member.disconnected_count", Some(&params))
+                        .await;
                 }
                 return String::new();
             }
@@ -105,15 +105,15 @@ impl AuditLogFormatter for MemberFormatter {
                     }
                 }
                 MemberAction::BanAdd => {
-                    if let Some(days) = opts.delete_member_days {
-                        if days > 0 {
-                            let mut params = HashMap::new();
-                            params.insert("days".to_string(), days.to_string());
-                            let deleted = alc
-                                .translate("audit_log.member.messages_deleted", Some(&params))
-                                .await;
-                            desc.push_str(&format!("\n{}", deleted));
-                        }
+                    if let Some(days) = opts.delete_member_days
+                        && days > 0
+                    {
+                        let mut params = HashMap::new();
+                        params.insert("days".to_string(), days.to_string());
+                        let deleted = alc
+                            .translate("audit_log.member.messages_deleted", Some(&params))
+                            .await;
+                        desc.push_str(&format!("\n{}", deleted));
                     }
                 }
                 _ => {}

--- a/crates/rustmail/src/handlers/audit_log/formatters/mod.rs
+++ b/crates/rustmail/src/handlers/audit_log/formatters/mod.rs
@@ -1096,7 +1096,7 @@ pub async fn format_change_value(alc: &AuditLogContext<'_>, change: &Change) -> 
                 true,
             ))
         }
-        Change::Unknown { .. } => None,
+        Change::Unknown => None,
         _ => None,
     }
 }

--- a/crates/rustmail/src/handlers/guild_ban_handler.rs
+++ b/crates/rustmail/src/handlers/guild_ban_handler.rs
@@ -70,10 +70,10 @@ async fn fetch_ban_audit(
     };
 
     for entry in entries.entries.iter() {
-        if let Some(target) = entry.target_id {
-            if target.get() == target_user_id {
-                return (Some(entry.user_id.to_string()), entry.reason.clone());
-            }
+        if let Some(target) = entry.target_id
+            && target.get() == target_user_id
+        {
+            return (Some(entry.user_id.to_string()), entry.reason.clone());
         }
     }
     (None, None)

--- a/crates/rustmail/src/handlers/guild_interaction_handler.rs
+++ b/crates/rustmail/src/handlers/guild_interaction_handler.rs
@@ -119,31 +119,29 @@ impl EventHandler for InteractionHandler {
                 }
             }
             Interaction::Command(command) => {
-                if self.maintenance_mode.load(Ordering::Relaxed) {
-                    if let Some(guild_id) = command.guild_id {
-                        if !is_interaction_user_maintenance_exempt(
-                            &ctx,
-                            guild_id,
-                            command.user.id,
-                            &self.config,
+                if self.maintenance_mode.load(Ordering::Relaxed)
+                    && let Some(guild_id) = command.guild_id
+                    && !is_interaction_user_maintenance_exempt(
+                        &ctx,
+                        guild_id,
+                        command.user.id,
+                        &self.config,
+                    )
+                    .await
+                {
+                    defer_response(&ctx, &command).await.ok();
+
+                    let _ = MessageBuilder::system_message(&ctx, &self.config)
+                        .translated_content(
+                            "status.maintenance_mode_active",
+                            None,
+                            Some(command.user.id),
+                            command.guild_id.map(|g| g.get()),
                         )
                         .await
-                        {
-                            defer_response(&ctx, &command).await.ok();
-
-                            let _ = MessageBuilder::system_message(&ctx, &self.config)
-                                .translated_content(
-                                    "status.maintenance_mode_active",
-                                    None,
-                                    Some(command.user.id),
-                                    command.guild_id.map(|g| g.get()),
-                                )
-                                .await
-                                .send_interaction_followup(&command, true)
-                                .await;
-                            return;
-                        }
-                    }
+                        .send_interaction_followup(&command, true)
+                        .await;
+                    return;
                 }
 
                 let ctx = ctx.clone();
@@ -156,12 +154,12 @@ impl EventHandler for InteractionHandler {
                         .run(&ctx, &command, &options, &config, Arc::new(self.clone()))
                         .await;
 
-                    if let Err(e) = result {
-                        if let Some(error_handler) = &self.config.error_handler {
-                            let _ = error_handler
-                                .reply_to_command_with_error(&ctx, &command, &e)
-                                .await;
-                        }
+                    if let Err(e) = result
+                        && let Some(error_handler) = &self.config.error_handler
+                    {
+                        let _ = error_handler
+                            .reply_to_command_with_error(&ctx, &command, &e)
+                            .await;
                     }
                 } else {
                     eprintln!("Command {} not found", command.data.name);

--- a/crates/rustmail/src/handlers/guild_messages_handler.rs
+++ b/crates/rustmail/src/handlers/guild_messages_handler.rs
@@ -179,22 +179,21 @@ async fn manage_incoming_message(
                 return Err(error);
             }
 
-            if let Ok(thread) = fetch_thread(pool, &channel_id_str).await {
-                if let Ok(existed) = delete_scheduled_closure(&thread.id, pool).await {
-                    if existed {
-                        let _ = MessageBuilder::system_message(ctx, config)
-                            .translated_content(
-                                "close.auto_canceled_on_message",
-                                None,
-                                Some(msg.author.id),
-                                None,
-                            )
-                            .await
-                            .to_channel(channel_id)
-                            .send(true)
-                            .await;
-                    }
-                }
+            if let Ok(thread) = fetch_thread(pool, &channel_id_str).await
+                && let Ok(existed) = delete_scheduled_closure(&thread.id, pool).await
+                && existed
+            {
+                let _ = MessageBuilder::system_message(ctx, config)
+                    .translated_content(
+                        "close.auto_canceled_on_message",
+                        None,
+                        Some(msg.author.id),
+                        None,
+                    )
+                    .await
+                    .to_channel(channel_id)
+                    .send(true)
+                    .await;
             }
         }
     } else {
@@ -291,16 +290,16 @@ impl EventHandler for GuildMessagesHandler {
                 command_name = &message_content[self.config.command.prefix.len()..i];
             }
 
-            if self.maintenance_mode.load(Ordering::Relaxed) {
-                if !is_user_maintenance_exempt(&ctx, &msg, &self.config).await {
-                    let _ = MessageBuilder::system_message(&ctx, &self.config)
-                        .translated_content("status.maintenance_mode_active", None, None, None)
-                        .await
-                        .to_channel(msg.channel_id)
-                        .send(true)
-                        .await;
-                    return;
-                }
+            if self.maintenance_mode.load(Ordering::Relaxed)
+                && !is_user_maintenance_exempt(&ctx, &msg, &self.config).await
+            {
+                let _ = MessageBuilder::system_message(&ctx, &self.config)
+                    .translated_content("status.maintenance_mode_active", None, None, None)
+                    .await
+                    .to_channel(msg.channel_id)
+                    .send(true)
+                    .await;
+                return;
             }
 
             let commands_lock = self.commands.lock().await;
@@ -327,17 +326,16 @@ impl EventHandler for GuildMessagesHandler {
 
         if let Some(guild_id) = msg.guild_id {
             let staff_guild_id = self.config.bot.get_staff_guild_id();
-            if guild_id.get() == staff_guild_id && !msg.author.bot {
-                if let Some(pool) = &self.config.db_pool {
-                    let channel_id_str = msg.channel_id.to_string();
-                    if let Some(_thread) = get_thread_by_channel_id(&channel_id_str, pool).await {
-                        if let Err(e) =
-                            insert_internal_message(&ctx, &msg, &_thread.id, pool, &self.config)
-                                .await
-                        {
-                            eprintln!("Failed to record internal message: {}", e);
-                        }
-                    }
+            if guild_id.get() == staff_guild_id
+                && !msg.author.bot
+                && let Some(pool) = &self.config.db_pool
+            {
+                let channel_id_str = msg.channel_id.to_string();
+                if let Some(_thread) = get_thread_by_channel_id(&channel_id_str, pool).await
+                    && let Err(e) =
+                        insert_internal_message(&ctx, &msg, &_thread.id, pool, &self.config).await
+                {
+                    eprintln!("Failed to record internal message: {}", e);
                 }
             }
         }

--- a/crates/rustmail/src/handlers/guild_moderation_handler.rs
+++ b/crates/rustmail/src/handlers/guild_moderation_handler.rs
@@ -56,17 +56,16 @@ async fn manage_creating_ticket_via_opening_thread(
         channel.id
     };
 
-    if let Some(pool) = &config.db_pool {
-        if get_thread_by_channel_id(&channel_id_inner.to_string(), pool)
+    if let Some(pool) = &config.db_pool
+        && get_thread_by_channel_id(&channel_id_inner.to_string(), pool)
             .await
             .is_some()
-        {
-            return;
-        }
+    {
+        return;
     }
 
-    let yes = get_translated_message(&config, "general.yes", None, None, None, None).await;
-    let no = get_translated_message(&config, "general.no", None, None, None, None).await;
+    let yes = get_translated_message(config, "general.yes", None, None, None, None).await;
+    let no = get_translated_message(config, "general.no", None, None, None, None).await;
     let res_button = make_buttons(&[
         (
             yes.as_ref(),
@@ -82,7 +81,7 @@ async fn manage_creating_ticket_via_opening_thread(
         ),
     ]);
 
-    let _ = MessageBuilder::system_message(&ctx, &config)
+    let _ = MessageBuilder::system_message(ctx, config)
         .translated_content("thread.ask_create_ticket", None, None, None)
         .await
         .components(res_button)
@@ -99,15 +98,15 @@ impl EventHandler for GuildModerationHandler {
         entry: AuditLogEntry,
         guild_id: GuildId,
     ) {
-        if let Action::Channel(ChannelAction::Create) = entry.action {
-            if entry.user_id != ctx.cache.current_user().id {
-                let channel_id = match entry.target_id {
-                    Some(id) => ChannelId::new(id.get()),
-                    None => return,
-                };
-                manage_creating_ticket_via_opening_thread(&ctx, &self.config, guild_id, channel_id)
-                    .await;
-            }
+        if let Action::Channel(ChannelAction::Create) = entry.action
+            && entry.user_id != ctx.cache.current_user().id
+        {
+            let channel_id = match entry.target_id {
+                Some(id) => ChannelId::new(id.get()),
+                None => return,
+            };
+            manage_creating_ticket_via_opening_thread(&ctx, &self.config, guild_id, channel_id)
+                .await;
         }
 
         if !self.config.bot.enable_discord_logs {

--- a/crates/rustmail/src/main.rs
+++ b/crates/rustmail/src/main.rs
@@ -38,7 +38,7 @@ mod utils;
 struct Assets;
 
 async fn static_handler(path: Option<Path<String>>) -> Response {
-    let path = path.map(|p| p.0).unwrap_or_else(|| "".to_string());
+    let path = path.map(|p| p.0).unwrap_or_default();
 
     let path = if path.is_empty() || path == "/" {
         "index.html".to_string()
@@ -161,7 +161,7 @@ async fn run_setup_mode() {
 async fn main() {
     let args: Vec<String> = env::args().collect();
 
-    for arg in args.iter().skip(1) {
+    if let Some(arg) = args.get(1) {
         match arg.as_str() {
             "-v" | "--version" => {
                 print_version();
@@ -242,14 +242,8 @@ async fn main() {
                 _ = tokio::signal::ctrl_c() => { println!("Shutting down"); }
             }
         } else {
-            loop {
-                tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {
-                        println!("Shutting down");
-                        break;
-                    }
-                }
-            }
+            let _ = tokio::signal::ctrl_c().await;
+            println!("Shutting down");
         }
     }
 }

--- a/crates/rustmail/src/main.rs
+++ b/crates/rustmail/src/main.rs
@@ -1,5 +1,8 @@
 use crate::bot::{init_bot_state, start_bot_if_config_valid};
+use crate::config::{resolve_bind_address, resolve_config_path, resolve_port};
 use crate::prelude::api::*;
+use crate::setup::router::create_setup_router;
+use crate::setup::state::new_setup_state;
 use axum::extract::Path;
 use axum::response::Response;
 #[cfg(test)]
@@ -26,6 +29,7 @@ mod i18n;
 mod modules;
 mod panel_commands;
 mod prelude;
+mod setup;
 mod types;
 mod utils;
 
@@ -90,13 +94,51 @@ fn print_help() {
     println!();
     println!("CONFIGURATION:");
     println!("    Rustmail requires a config.toml file in the current directory.");
-    println!("    Use the online configurator: https://config.rustmail.rs");
+    println!("    If no configuration is found, a setup wizard will launch on port 3002.");
+    println!();
+    println!("ENVIRONMENT VARIABLES:");
+    println!("    RUSTMAIL_CONFIG_PATH      Path to config.toml (default: config.toml)");
+    println!("    RUSTMAIL_BOT_TOKEN        Overrides bot.token from config.toml");
+    println!("    RUSTMAIL_BOT_CLIENT_ID    Overrides bot.client_id from config.toml");
+    println!("    RUSTMAIL_BOT_CLIENT_SECRET Overrides bot.client_secret from config.toml");
+    println!("    RUSTMAIL_DATABASE_URL     Database path (default: db/db.sqlite)");
+    println!("    RUSTMAIL_BIND_ADDRESS     Bind address (default: 0.0.0.0)");
+    println!("    RUSTMAIL_PORT             Port (default: 3002)");
     println!();
     println!("DOCUMENTATION:");
     println!("    https://docs.rustmail.rs");
     println!();
     println!("SOURCE CODE:");
     println!("    https://github.com/Rustmail/rustmail");
+}
+
+async fn run_setup_mode() {
+    let bind_address = resolve_bind_address("0.0.0.0");
+    let port = resolve_port(3002);
+
+    let setup_state = new_setup_state();
+
+    let app = create_setup_router(setup_state)
+        .route("/", axum::routing::get(static_handler))
+        .route("/{*path}", axum::routing::get(static_handler))
+        .layer(CompressionLayer::new());
+
+    let addr = format!("{}:{}", bind_address, port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .unwrap_or_else(|_| panic!("Failed to bind to {}", addr));
+
+    println!("No configuration found.");
+    println!("Setup wizard available at http://{}:{}", bind_address, port);
+    println!("Open this URL in your browser to configure Rustmail.");
+
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
+    .unwrap();
 }
 
 #[tokio::main]
@@ -121,7 +163,18 @@ async fn main() {
         }
     }
 
-    let bot_state = init_bot_state().await;
+    let config_path = resolve_config_path("config.toml");
+    let bot_state = init_bot_state(&config_path).await;
+
+    let has_config = {
+        let state = bot_state.lock().await;
+        state.config.is_some()
+    };
+
+    if !has_config {
+        run_setup_mode().await;
+        return;
+    }
 
     let _ = start_bot_if_config_valid(bot_state.clone()).await;
 
@@ -140,26 +193,17 @@ async fn main() {
                     .route("/{*path}", axum::routing::get(static_handler))
                     .layer(CompressionLayer::new());
 
-                let bind_address = config
-                    .bot
-                    .ip
-                    .as_ref()
-                    .and_then(|ip| {
-                        if ip.parse::<std::net::IpAddr>().is_ok() {
-                            Some(ip.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_else(|| "0.0.0.0".to_string());
+                let bind_address = resolve_bind_address("0.0.0.0");
+                let port = resolve_port(3002);
 
                 let listener =
-                    match tokio::net::TcpListener::bind(format!("{}:3002", bind_address)).await {
+                    match tokio::net::TcpListener::bind(format!("{}:{}", bind_address, port)).await
+                    {
                         Ok(l) => l,
                         Err(e) => {
                             eprintln!(
-                                "Failed to bind to {}:3002 ({}), falling back to 0.0.0.0:3002",
-                                bind_address, e
+                                "Failed to bind to {}:{} ({}), falling back to 0.0.0.0:3002",
+                                bind_address, port, e
                             );
                             tokio::net::TcpListener::bind("0.0.0.0:3002")
                                 .await

--- a/crates/rustmail/src/main.rs
+++ b/crates/rustmail/src/main.rs
@@ -118,6 +118,12 @@ async fn run_setup_mode() {
 
     let setup_state = new_setup_state();
 
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel(1);
+    {
+        let mut state = setup_state.lock().await;
+        state.shutdown_tx = Some(shutdown_tx);
+    }
+
     let app = create_setup_router(setup_state)
         .route("/", axum::routing::get(static_handler))
         .route("/{*path}", axum::routing::get(static_handler))
@@ -136,7 +142,17 @@ async fn run_setup_mode() {
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
-    .with_graceful_shutdown(shutdown_signal())
+    .with_graceful_shutdown(async move {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                println!("Setup complete, transitioning to bot mode...");
+            }
+            _ = shutdown_signal() => {
+                println!("Shutdown signal received during setup");
+                process::exit(0);
+            }
+        }
+    })
     .await
     .unwrap();
 }
@@ -164,7 +180,7 @@ async fn main() {
     }
 
     let config_path = resolve_config_path("config.toml");
-    let bot_state = init_bot_state(&config_path).await;
+    let mut bot_state = init_bot_state(&config_path).await;
 
     let has_config = {
         let state = bot_state.lock().await;
@@ -173,7 +189,7 @@ async fn main() {
 
     if !has_config {
         run_setup_mode().await;
-        return;
+        bot_state = init_bot_state(&config_path).await;
     }
 
     let _ = start_bot_if_config_valid(bot_state.clone()).await;
@@ -194,7 +210,7 @@ async fn main() {
                     .layer(CompressionLayer::new());
 
                 let bind_address = resolve_bind_address("0.0.0.0");
-                let port = resolve_port(3002);
+                let port = resolve_port(config.bot.panel_port);
 
                 let listener =
                     match tokio::net::TcpListener::bind(format!("{}:{}", bind_address, port)).await

--- a/crates/rustmail/src/modules/categories.rs
+++ b/crates/rustmail/src/modules/categories.rs
@@ -26,10 +26,10 @@ fn build_category_components(
         let mut btn = CreateButton::new(format!("category:pick:{}", cat.id))
             .label(cat.name.clone())
             .style(ButtonStyle::Primary);
-        if let Some(emoji) = cat.emoji.as_deref() {
-            if let Some(react) = parse_emoji(emoji) {
-                btn = btn.emoji(react);
-            }
+        if let Some(emoji) = cat.emoji.as_deref()
+            && let Some(react) = parse_emoji(emoji)
+        {
+            btn = btn.emoji(react);
         }
         buttons.push(btn);
     }
@@ -169,24 +169,16 @@ pub fn schedule_category_timeout(ctx: &Context, config: &Config, user_id: i64, e
             Some(p) => p,
             None => return,
         };
-        match get_pending_selection(user_id, pool).await {
-            Ok(Some(pending)) => {
-                if pending.expires_at <= Utc::now().timestamp() {
-                    if let Err(e) =
-                        finalize_with_category(&ctx_clone, &config_clone, user_id, None).await
-                    {
-                        eprintln!("Failed to finalize expired selection: {e:?}");
-                    }
-                } else {
-                    schedule_category_timeout(
-                        &ctx_clone,
-                        &config_clone,
-                        user_id,
-                        pending.expires_at,
-                    );
+        if let Ok(Some(pending)) = get_pending_selection(user_id, pool).await {
+            if pending.expires_at <= Utc::now().timestamp() {
+                if let Err(e) =
+                    finalize_with_category(&ctx_clone, &config_clone, user_id, None).await
+                {
+                    eprintln!("Failed to finalize expired selection: {e:?}");
                 }
+            } else {
+                schedule_category_timeout(&ctx_clone, &config_clone, user_id, pending.expires_at);
             }
-            _ => {}
         }
     });
 }
@@ -237,22 +229,20 @@ pub async fn finalize_with_category(
     )
     .await?;
 
-    if is_new {
-        if let Some(cat_id) = ticket_cat_id.as_deref() {
-            if let Err(e) = mention_category_roles(ctx, pool, target_channel_id, cat_id).await {
-                eprintln!("Failed to mention category roles: {e:?}");
-            }
-        }
+    if is_new
+        && let Some(cat_id) = ticket_cat_id.as_deref()
+        && let Err(e) = mention_category_roles(ctx, pool, target_channel_id, cat_id).await
+    {
+        eprintln!("Failed to mention category roles: {e:?}");
     }
 
     let dm_channel = ChannelId::new(pending.dm_channel_id.parse::<u64>().unwrap_or(0));
     for mid in &pending.queued_msg_ids {
-        if let Ok(id_u64) = mid.parse::<u64>() {
-            if let Ok(m) = dm_channel.message(&ctx.http, id_u64).await {
-                if let Err(e) = send_to_thread(ctx, target_channel_id, &m, config, false).await {
-                    eprintln!("Failed to forward queued DM message: {e:?}");
-                }
-            }
+        if let Ok(id_u64) = mid.parse::<u64>()
+            && let Ok(m) = dm_channel.message(&ctx.http, id_u64).await
+            && let Err(e) = send_to_thread(ctx, target_channel_id, &m, config, false).await
+        {
+            eprintln!("Failed to forward queued DM message: {e:?}");
         }
     }
 

--- a/crates/rustmail/src/modules/commands.rs
+++ b/crates/rustmail/src/modules/commands.rs
@@ -23,9 +23,9 @@ async fn handle_logs_action(
     let mut store = pagination.lock().await;
 
     let next_button =
-        get_translated_message(&config, "logs_command.next", None, None, None, None).await;
+        get_translated_message(config, "logs_command.next", None, None, None, None).await;
     let prev_button =
-        get_translated_message(&config, "logs_command.prev", None, None, None, None).await;
+        get_translated_message(config, "logs_command.prev", None, None, None, None).await;
 
     if let Some(ctx_data) = store.get_mut(session_id) {
         if page == 0 && ctx_data.current_page > 0 {
@@ -63,7 +63,7 @@ async fn handle_logs_action(
             ),
         ]);
 
-        let response = MessageBuilder::system_message(&ctx, &config)
+        let response = MessageBuilder::system_message(ctx, config)
             .content(new_content)
             .components(components)
             .to_channel(ctx_data.channel_id)

--- a/crates/rustmail/src/modules/message_recovery.rs
+++ b/crates/rustmail/src/modules/message_recovery.rs
@@ -167,10 +167,10 @@ async fn recover_messages_for_thread(
             continue;
         }
 
-        let _ = MessageBuilder::begin_user_incoming(&ctx, config, thread.id.clone(), &message)
+        let _ = MessageBuilder::begin_user_incoming(ctx, config, thread.id.clone(), &message)
             .to_thread(channel_id)
             .content(content.clone())
-            .send_and_record(&pool)
+            .send_and_record(pool)
             .await;
 
         recovered_count += 1;

--- a/crates/rustmail/src/modules/reminders.rs
+++ b/crates/rustmail/src/modules/reminders.rs
@@ -17,7 +17,7 @@ pub async fn load_reminders(
     });
 
     for reminder in reminders {
-        spawn_reminder(&reminder, None, &ctx, &config, &pool, shutdown.clone());
+        spawn_reminder(&reminder, None, ctx, config, pool, shutdown.clone());
     }
     println!("All pending reminders have been scheduled.");
 }

--- a/crates/rustmail/src/modules/scheduled_closures.rs
+++ b/crates/rustmail/src/modules/scheduled_closures.rs
@@ -15,75 +15,69 @@ pub fn schedule_one(ctx: &Context, config: &Config, thread_id: String, close_at:
         if delay_secs > 0 {
             sleep(Duration::from_secs(delay_secs)).await;
         }
-        if let Some(pool) = config_clone.db_pool.as_ref() {
-            if let Ok(Some(current)) = get_scheduled_closure(&thread_id, pool).await {
-                if current.close_at <= Utc::now().timestamp() {
-                    if let Some(thread) = get_thread_by_id(&thread_id, pool).await {
-                        let channel_id =
-                            ChannelId::new(thread.channel_id.parse::<u64>().unwrap_or(0));
-                        let user_id = UserId::new(thread.user_id as u64);
+        if let Some(pool) = config_clone.db_pool.as_ref()
+            && let Ok(Some(current)) = get_scheduled_closure(&thread_id, pool).await
+        {
+            if current.close_at <= Utc::now().timestamp() {
+                if let Some(thread) = get_thread_by_id(&thread_id, pool).await {
+                    let channel_id = ChannelId::new(thread.channel_id.parse::<u64>().unwrap_or(0));
+                    let user_id = UserId::new(thread.user_id as u64);
 
-                        let _ = close_thread(
-                            &thread_id,
-                            &current.closed_by,
-                            &current.category_id,
-                            &current.category_name,
-                            current.required_permissions.parse::<u64>().unwrap_or(0),
-                            pool,
-                        )
-                        .await;
-                        let _ = delete_scheduled_closure(&thread_id, pool).await;
+                    let _ = close_thread(
+                        &thread_id,
+                        &current.closed_by,
+                        &current.category_id,
+                        &current.category_name,
+                        current.required_permissions.parse::<u64>().unwrap_or(0),
+                        pool,
+                    )
+                    .await;
+                    let _ = delete_scheduled_closure(&thread_id, pool).await;
 
-                        if config_clone.bot.enable_rustmail_logs {
-                            if let Some(logs_channel_id) = config_clone.bot.logs_channel_id {
-                                let base_url = config_clone
-                                    .bot
-                                    .redirect_url
-                                    .trim_end_matches("/api/auth/callback")
-                                    .trim_end_matches('/');
+                    if config_clone.bot.enable_rustmail_logs
+                        && let Some(logs_channel_id) = config_clone.bot.logs_channel_id
+                    {
+                        let base_url = config_clone
+                            .bot
+                            .redirect_url
+                            .trim_end_matches("/api/auth/callback")
+                            .trim_end_matches('/');
 
-                                let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
+                        let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
 
-                                let mut params = std::collections::HashMap::new();
-                                params.insert("username".to_string(), thread.user_name.clone());
-                                params.insert("user_id".to_string(), thread.user_id.to_string());
-                                params.insert("panel_url".to_string(), panel_url);
+                        let mut params = std::collections::HashMap::new();
+                        params.insert("username".to_string(), thread.user_name.clone());
+                        params.insert("user_id".to_string(), thread.user_id.to_string());
+                        params.insert("panel_url".to_string(), panel_url);
 
-                                let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
-                                    .translated_content(
-                                        "logs.ticket_closed",
-                                        Some(&params),
-                                        None,
-                                        None,
-                                    )
-                                    .await
-                                    .to_channel(ChannelId::new(logs_channel_id))
-                                    .send(true)
-                                    .await;
-                            }
-                        }
-
-                        let effective_silent =
-                            current.silent || is_thread_silent(&thread_id, pool).await;
-                        if !effective_silent {
-                            let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
-                                .content(&config_clone.bot.close_message)
-                                .to_user(user_id)
-                                .send(true)
-                                .await;
-                        }
-                        let _ = channel_id.delete(&ctx_clone.http).await;
-                    } else {
-                        let _ = delete_scheduled_closure(&thread_id, pool).await;
+                        let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
+                            .translated_content("logs.ticket_closed", Some(&params), None, None)
+                            .await
+                            .to_channel(ChannelId::new(logs_channel_id))
+                            .send(true)
+                            .await;
                     }
+
+                    let effective_silent =
+                        current.silent || is_thread_silent(&thread_id, pool).await;
+                    if !effective_silent {
+                        let _ = MessageBuilder::system_message(&ctx_clone, &config_clone)
+                            .content(&config_clone.bot.close_message)
+                            .to_user(user_id)
+                            .send(true)
+                            .await;
+                    }
+                    let _ = channel_id.delete(&ctx_clone.http).await;
                 } else {
-                    schedule_one(
-                        &ctx_clone,
-                        &config_clone,
-                        thread_id.clone(),
-                        current.close_at,
-                    );
+                    let _ = delete_scheduled_closure(&thread_id, pool).await;
                 }
+            } else {
+                schedule_one(
+                    &ctx_clone,
+                    &config_clone,
+                    thread_id.clone(),
+                    current.close_at,
+                );
             }
         }
     });
@@ -118,28 +112,28 @@ pub async fn hydrate_scheduled_closures(ctx: &Context, config: &Config) {
                 .await;
                 let _ = delete_scheduled_closure(&thread.id, pool).await;
 
-                if config.bot.enable_rustmail_logs {
-                    if let Some(logs_channel_id) = config.bot.logs_channel_id {
-                        let base_url = config
-                            .bot
-                            .redirect_url
-                            .trim_end_matches("/api/auth/callback")
-                            .trim_end_matches('/');
+                if config.bot.enable_rustmail_logs
+                    && let Some(logs_channel_id) = config.bot.logs_channel_id
+                {
+                    let base_url = config
+                        .bot
+                        .redirect_url
+                        .trim_end_matches("/api/auth/callback")
+                        .trim_end_matches('/');
 
-                        let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
+                    let panel_url = format!("{}/panel/tickets/{}", base_url, thread.id);
 
-                        let mut params = std::collections::HashMap::new();
-                        params.insert("username".to_string(), thread.user_name.clone());
-                        params.insert("user_id".to_string(), thread.user_id.to_string());
-                        params.insert("panel_url".to_string(), panel_url);
+                    let mut params = std::collections::HashMap::new();
+                    params.insert("username".to_string(), thread.user_name.clone());
+                    params.insert("user_id".to_string(), thread.user_id.to_string());
+                    params.insert("panel_url".to_string(), panel_url);
 
-                        let _ = MessageBuilder::system_message(ctx, config)
-                            .translated_content("logs.ticket_closed", Some(&params), None, None)
-                            .await
-                            .to_channel(ChannelId::new(logs_channel_id))
-                            .send(true)
-                            .await;
-                    }
+                    let _ = MessageBuilder::system_message(ctx, config)
+                        .translated_content("logs.ticket_closed", Some(&params), None, None)
+                        .await
+                        .to_channel(ChannelId::new(logs_channel_id))
+                        .send(true)
+                        .await;
                 }
 
                 let effective_silent = sc.silent || is_thread_silent(&thread.id, pool).await;

--- a/crates/rustmail/src/modules/threads.rs
+++ b/crates/rustmail/src/modules/threads.rs
@@ -4,8 +4,8 @@ use crate::prelude::errors::*;
 use crate::prelude::i18n::*;
 use crate::prelude::utils::*;
 use serenity::all::{
-    ActionRowComponent, Channel, ChannelId, ComponentInteraction, Context, CreateChannel,
-    CreateInteractionResponseFollowup, GuildId, Message, ModalInteraction, UserId,
+    ActionRowComponent, Channel, ChannelId, ComponentInteraction, Context, CreateChannel, GuildId,
+    Message, ModalInteraction, UserId,
 };
 use serenity::builder::{CreateInteractionResponse, EditChannel, EditMessage};
 use std::collections::HashMap;
@@ -50,10 +50,10 @@ pub async fn create_or_get_thread_for_user(
             e
         })?;
 
-    if let Some(cat_id) = ticket_category_id {
-        if let Err(e) = set_thread_category(&thread_id, Some(cat_id), pool).await {
-            eprintln!("Failed to set thread category for thread {thread_id}: {e}");
-        }
+    if let Some(cat_id) = ticket_category_id
+        && let Err(e) = set_thread_category(&thread_id, Some(cat_id), pool).await
+    {
+        eprintln!("Failed to set thread category for thread {thread_id}: {e}");
     }
 
     let canonical_channel_id_str = get_thread_channel_by_user_id(user_id, pool).await;
@@ -92,7 +92,7 @@ pub async fn create_or_get_thread_for_user(
         };
 
         let logs_info = get_translated_message(
-            &config,
+            config,
             "new_thread.show_logs",
             Some(&params),
             None,
@@ -254,20 +254,18 @@ pub async fn handle_thread_modal_interaction(
                         let _ = interaction
                             .create_followup(
                                 &ctx.http,
-                                CreateInteractionResponseFollowup::from(
-                                    MessageBuilder::system_message(ctx, config)
-                                        .translated_content(
-                                            "thread.modal_invalid_user_id",
-                                            None,
-                                            None,
-                                            None,
-                                        )
-                                        .await
-                                        .to_channel(interaction.channel_id)
-                                        .build_interaction_message_followup()
-                                        .await
-                                        .ephemeral(true),
-                                ),
+                                MessageBuilder::system_message(ctx, config)
+                                    .translated_content(
+                                        "thread.modal_invalid_user_id",
+                                        None,
+                                        None,
+                                        None,
+                                    )
+                                    .await
+                                    .to_channel(interaction.channel_id)
+                                    .build_interaction_message_followup()
+                                    .await
+                                    .ephemeral(true),
                             )
                             .await;
                         return Ok(());
@@ -285,20 +283,13 @@ pub async fn handle_thread_modal_interaction(
                     let _ = interaction
                         .create_followup(
                             &ctx.http,
-                            CreateInteractionResponseFollowup::from(
-                                MessageBuilder::system_message(ctx, config)
-                                    .translated_content(
-                                        "thread.modal_user_not_found",
-                                        None,
-                                        None,
-                                        None,
-                                    )
-                                    .await
-                                    .to_channel(interaction.channel_id)
-                                    .build_interaction_message_followup()
-                                    .await
-                                    .ephemeral(true),
-                            ),
+                            MessageBuilder::system_message(ctx, config)
+                                .translated_content("thread.modal_user_not_found", None, None, None)
+                                .await
+                                .to_channel(interaction.channel_id)
+                                .build_interaction_message_followup()
+                                .await
+                                .ephemeral(true),
                         )
                         .await;
                     return Ok(());
@@ -313,15 +304,13 @@ pub async fn handle_thread_modal_interaction(
                 let _ = interaction
                     .create_followup(
                         &ctx.http,
-                        CreateInteractionResponseFollowup::from(
-                            MessageBuilder::system_message(ctx, config)
-                                .translated_content("thread.modal_bot_user", None, None, None)
-                                .await
-                                .to_channel(interaction.channel_id)
-                                .build_interaction_message_followup()
-                                .await
-                                .ephemeral(true),
-                        ),
+                        MessageBuilder::system_message(ctx, config)
+                            .translated_content("thread.modal_bot_user", None, None, None)
+                            .await
+                            .to_channel(interaction.channel_id)
+                            .build_interaction_message_followup()
+                            .await
+                            .ephemeral(true),
                     )
                     .await;
                 return Ok(());
@@ -344,20 +333,13 @@ pub async fn handle_thread_modal_interaction(
                 let _ = interaction
                     .create_followup(
                         &ctx.http,
-                        CreateInteractionResponseFollowup::from(
-                            MessageBuilder::system_message(ctx, config)
-                                .translated_content(
-                                    "thread.already_exists",
-                                    Some(&params),
-                                    None,
-                                    None,
-                                )
-                                .await
-                                .to_channel(interaction.channel_id)
-                                .build_interaction_message_followup()
-                                .await
-                                .ephemeral(true),
-                        ),
+                        MessageBuilder::system_message(ctx, config)
+                            .translated_content("thread.already_exists", Some(&params), None, None)
+                            .await
+                            .to_channel(interaction.channel_id)
+                            .build_interaction_message_followup()
+                            .await
+                            .ephemeral(true),
                     )
                     .await;
                 drop(guard);
@@ -370,20 +352,13 @@ pub async fn handle_thread_modal_interaction(
                     let _ = interaction
                         .create_followup(
                             &ctx.http,
-                            CreateInteractionResponseFollowup::from(
-                                MessageBuilder::system_message(ctx, config)
-                                    .translated_content(
-                                        "thread.not_a_thread_channel",
-                                        None,
-                                        None,
-                                        None,
-                                    )
-                                    .await
-                                    .to_channel(interaction.channel_id)
-                                    .build_interaction_message_followup()
-                                    .await
-                                    .ephemeral(true),
-                            ),
+                            MessageBuilder::system_message(ctx, config)
+                                .translated_content("thread.not_a_thread_channel", None, None, None)
+                                .await
+                                .to_channel(interaction.channel_id)
+                                .build_interaction_message_followup()
+                                .await
+                                .ephemeral(true),
                         )
                         .await;
                     drop(guard);
@@ -396,20 +371,13 @@ pub async fn handle_thread_modal_interaction(
                     let _ = interaction
                         .create_followup(
                             &ctx.http,
-                            CreateInteractionResponseFollowup::from(
-                                MessageBuilder::system_message(ctx, config)
-                                    .translated_content(
-                                        "thread.not_a_thread_channel",
-                                        None,
-                                        None,
-                                        None,
-                                    )
-                                    .await
-                                    .to_channel(interaction.channel_id)
-                                    .build_interaction_message_followup()
-                                    .await
-                                    .ephemeral(true),
-                            ),
+                            MessageBuilder::system_message(ctx, config)
+                                .translated_content("thread.not_a_thread_channel", None, None, None)
+                                .await
+                                .to_channel(interaction.channel_id)
+                                .build_interaction_message_followup()
+                                .await
+                                .ephemeral(true),
                         )
                         .await;
                     drop(guard);
@@ -419,15 +387,13 @@ pub async fn handle_thread_modal_interaction(
                 let _ = interaction
                     .create_followup(
                         &ctx.http,
-                        CreateInteractionResponseFollowup::from(
-                            MessageBuilder::system_message(ctx, config)
-                                .translated_content("thread.not_a_thread_channel", None, None, None)
-                                .await
-                                .to_channel(interaction.channel_id)
-                                .build_interaction_message_followup()
-                                .await
-                                .ephemeral(true),
-                        ),
+                        MessageBuilder::system_message(ctx, config)
+                            .translated_content("thread.not_a_thread_channel", None, None, None)
+                            .await
+                            .to_channel(interaction.channel_id)
+                            .build_interaction_message_followup()
+                            .await
+                            .ephemeral(true),
                     )
                     .await;
                 drop(guard);
@@ -449,15 +415,13 @@ pub async fn handle_thread_modal_interaction(
                 let _ = interaction
                     .create_followup(
                         &ctx.http,
-                        CreateInteractionResponseFollowup::from(
-                            MessageBuilder::system_message(ctx, config)
-                                .translated_content("thread.creation_failed", None, None, None)
-                                .await
-                                .to_channel(interaction.channel_id)
-                                .build_interaction_message_followup()
-                                .await
-                                .ephemeral(true),
-                        ),
+                        MessageBuilder::system_message(ctx, config)
+                            .translated_content("thread.creation_failed", None, None, None)
+                            .await
+                            .to_channel(interaction.channel_id)
+                            .build_interaction_message_followup()
+                            .await
+                            .ephemeral(true),
                     )
                     .await;
                 drop(guard);
@@ -494,15 +458,13 @@ pub async fn handle_thread_modal_interaction(
             let _ = interaction
                 .create_followup(
                     &ctx.http,
-                    CreateInteractionResponseFollowup::from(
-                        MessageBuilder::system_message(ctx, config)
-                            .translated_content("thread.created", Some(&params), None, None)
-                            .await
-                            .to_channel(interaction.channel_id)
-                            .build_interaction_message_followup()
-                            .await
-                            .ephemeral(true),
-                    ),
+                    MessageBuilder::system_message(ctx, config)
+                        .translated_content("thread.created", Some(&params), None, None)
+                        .await
+                        .to_channel(interaction.channel_id)
+                        .build_interaction_message_followup()
+                        .await
+                        .ephemeral(true),
                 )
                 .await;
 
@@ -520,14 +482,12 @@ pub async fn handle_thread_modal_interaction(
             let _ = interaction
                 .create_followup(
                     &ctx.http,
-                    CreateInteractionResponseFollowup::from(
-                        MessageBuilder::system_message(ctx, config)
-                            .translated_content("thread.unknown_action", None, None, None)
-                            .await
-                            .to_channel(interaction.channel_id)
-                            .build_interaction_message_followup()
-                            .await,
-                    ),
+                    MessageBuilder::system_message(ctx, config)
+                        .translated_content("thread.unknown_action", None, None, None)
+                        .await
+                        .to_channel(interaction.channel_id)
+                        .build_interaction_message_followup()
+                        .await,
                 )
                 .await;
         }
@@ -556,15 +516,13 @@ pub async fn handle_thread_component_interaction(
             let _ = interaction
                 .create_followup(
                     &ctx.http,
-                    CreateInteractionResponseFollowup::from(
-                        MessageBuilder::system_message(ctx, config)
-                            .translated_content("thread.action_in_progress", None, None, None)
-                            .await
-                            .to_channel(interaction.channel_id)
-                            .build_interaction_message_followup()
-                            .await
-                            .ephemeral(true),
-                    ),
+                    MessageBuilder::system_message(ctx, config)
+                        .translated_content("thread.action_in_progress", None, None, None)
+                        .await
+                        .to_channel(interaction.channel_id)
+                        .build_interaction_message_followup()
+                        .await
+                        .ephemeral(true),
                 )
                 .await;
             return Ok(());
@@ -583,14 +541,12 @@ pub async fn handle_thread_component_interaction(
             let _ = interaction
                 .create_followup(
                     &ctx.http,
-                    CreateInteractionResponseFollowup::from(
-                        MessageBuilder::system_message(ctx, config)
-                            .translated_content("thread.thread_closing", Some(&params), None, None)
-                            .await
-                            .to_channel(interaction.channel_id)
-                            .build_interaction_message_followup()
-                            .await,
-                    ),
+                    MessageBuilder::system_message(ctx, config)
+                        .translated_content("thread.thread_closing", Some(&params), None, None)
+                        .await
+                        .to_channel(interaction.channel_id)
+                        .build_interaction_message_followup()
+                        .await,
                 )
                 .await;
 
@@ -602,14 +558,12 @@ pub async fn handle_thread_component_interaction(
             let _ = interaction
                 .create_followup(
                     &ctx.http,
-                    CreateInteractionResponseFollowup::from(
-                        MessageBuilder::system_message(ctx, config)
-                            .translated_content("thread.will_remain_open", None, None, None)
-                            .await
-                            .to_channel(interaction.channel_id)
-                            .build_interaction_message_followup()
-                            .await,
-                    ),
+                    MessageBuilder::system_message(ctx, config)
+                        .translated_content("thread.will_remain_open", None, None, None)
+                        .await
+                        .to_channel(interaction.channel_id)
+                        .build_interaction_message_followup()
+                        .await,
                 )
                 .await;
 
@@ -650,14 +604,12 @@ pub async fn handle_thread_component_interaction(
             let _ = interaction
                 .create_followup(
                     &ctx.http,
-                    CreateInteractionResponseFollowup::from(
-                        MessageBuilder::system_message(ctx, config)
-                            .translated_content("thread.unknown_action", None, None, None)
-                            .await
-                            .to_channel(interaction.channel_id)
-                            .build_interaction_message_followup()
-                            .await,
-                    ),
+                    MessageBuilder::system_message(ctx, config)
+                        .translated_content("thread.unknown_action", None, None, None)
+                        .await
+                        .to_channel(interaction.channel_id)
+                        .build_interaction_message_followup()
+                        .await,
                 )
                 .await;
         }

--- a/crates/rustmail/src/setup/handlers/mod.rs
+++ b/crates/rustmail/src/setup/handlers/mod.rs
@@ -1,0 +1,7 @@
+pub mod save;
+pub mod status;
+pub mod validate;
+
+pub use save::*;
+pub use status::*;
+pub use validate::*;

--- a/crates/rustmail/src/setup/handlers/mod.rs
+++ b/crates/rustmail/src/setup/handlers/mod.rs
@@ -1,7 +1,9 @@
+pub mod restart;
 pub mod save;
 pub mod status;
 pub mod validate;
 
+pub use restart::*;
 pub use save::*;
 pub use status::*;
 pub use validate::*;

--- a/crates/rustmail/src/setup/handlers/restart.rs
+++ b/crates/rustmail/src/setup/handlers/restart.rs
@@ -1,0 +1,26 @@
+use crate::setup::state::SharedSetupState;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use std::time::Duration;
+
+pub async fn handle_setup_restart(
+    State(setup_state): State<SharedSetupState>,
+) -> impl IntoResponse {
+    let tx = {
+        let mut state = setup_state.lock().await;
+        state.shutdown_tx.take()
+    };
+
+    // Spawn a task to send the shutdown signal after a short delay
+    // This allows the HTTP response to be sent to the frontend first
+    if let Some(tx) = tx {
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let _ = tx.send(()).await;
+        });
+    }
+
+    (StatusCode::OK, Json(serde_json::json!({ "success": true })))
+}

--- a/crates/rustmail/src/setup/handlers/save.rs
+++ b/crates/rustmail/src/setup/handlers/save.rs
@@ -102,6 +102,19 @@ pub async fn handle_setup_save(
         }
     };
 
+    let timezone = match payload.timezone.parse() {
+        Ok(timezone) => timezone,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "success": false,
+                    "error": format!("Invalid timezone: {}", payload.timezone)
+                })),
+            );
+        }
+    };
+
     let bot_config = BotConfig {
         token: payload.token,
         mode,
@@ -117,7 +130,7 @@ pub async fn handle_setup_save(
         client_id: payload.client_id.unwrap_or(0),
         client_secret: payload.client_secret.unwrap_or_default(),
         redirect_url: payload.redirect_url.unwrap_or_default(),
-        timezone: payload.timezone.parse().unwrap_or(chrono_tz::UTC),
+        timezone,
         logs_channel_id: payload.logs_channel_id,
         features_channel_id: payload.features_channel_id,
         ip: None,

--- a/crates/rustmail/src/setup/handlers/save.rs
+++ b/crates/rustmail/src/setup/handlers/save.rs
@@ -32,6 +32,7 @@ pub struct SaveConfigRequest {
     pub enable_features: bool,
     pub features_channel_id: Option<u64>,
     pub enable_panel: bool,
+    pub api_port: u16,
     pub client_id: Option<u64>,
     pub client_secret: Option<String>,
     pub redirect_url: Option<String>,
@@ -125,6 +126,7 @@ pub async fn handle_setup_save(
         ip: None,
         panel_super_admin_users: payload.panel_super_admin_users,
         panel_super_admin_roles: vec![],
+        panel_port: payload.api_port,
     };
 
     let config = Config {

--- a/crates/rustmail/src/setup/handlers/save.rs
+++ b/crates/rustmail/src/setup/handlers/save.rs
@@ -1,7 +1,4 @@
-use crate::config::{
-    Config, LanguageConfigExt, load_config, resolve_config_path, save_config_with_backup,
-    validate_config,
-};
+use crate::config::{Config, resolve_config_path, save_config_with_backup, validate_config};
 use crate::setup::state::SharedSetupState;
 use axum::Json;
 use axum::extract::State;

--- a/crates/rustmail/src/setup/handlers/save.rs
+++ b/crates/rustmail/src/setup/handlers/save.rs
@@ -1,0 +1,181 @@
+use crate::config::{
+    Config, LanguageConfigExt, load_config, resolve_config_path, save_config_with_backup,
+    validate_config,
+};
+use crate::setup::state::SharedSetupState;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use rustmail_types::{
+    BotConfig, CommandConfig, ErrorHandlingConfig, LanguageConfig, LogsConfig, NotificationsConfig,
+    ReminderConfig, ServerMode, ThreadConfig,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+pub struct SaveConfigRequest {
+    pub token: String,
+    pub bot_status: String,
+    pub welcome_message: String,
+    pub close_message: String,
+    pub typing_proxy_from_user: bool,
+    pub typing_proxy_from_staff: bool,
+    pub server_mode: String,
+    pub guild_id: Option<u64>,
+    pub community_guild_id: Option<u64>,
+    pub staff_guild_id: Option<u64>,
+    pub enable_rustmail_logs: bool,
+    pub enable_discord_logs: bool,
+    pub logs_channel_id: Option<u64>,
+    pub enable_features: bool,
+    pub features_channel_id: Option<u64>,
+    pub enable_panel: bool,
+    pub client_id: Option<u64>,
+    pub client_secret: Option<String>,
+    pub redirect_url: Option<String>,
+    pub panel_super_admin_users: Vec<u64>,
+    pub inbox_category_id: u64,
+    pub command_prefix: String,
+    pub user_message_color: String,
+    pub staff_message_color: String,
+    pub system_message_color: String,
+    pub embedded_message: bool,
+    pub block_quote: bool,
+    pub time_to_close_thread: u64,
+    pub create_ticket_by_create_channel: bool,
+    pub close_on_leave: bool,
+    pub auto_archive_duration: u16,
+    pub default_language: String,
+    pub fallback_language: String,
+    pub timezone: String,
+}
+
+pub async fn handle_setup_save(
+    State(setup_state): State<SharedSetupState>,
+    Json(payload): Json<SaveConfigRequest>,
+) -> impl IntoResponse {
+    let mode = match payload.server_mode.as_str() {
+        "dual" => {
+            let community = match payload.community_guild_id {
+                Some(id) => id,
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "success": false,
+                            "error": "community_guild_id is required for dual mode"
+                        })),
+                    );
+                }
+            };
+            let staff = match payload.staff_guild_id {
+                Some(id) => id,
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "success": false,
+                            "error": "staff_guild_id is required for dual mode"
+                        })),
+                    );
+                }
+            };
+            ServerMode::Dual {
+                community_guild_id: community,
+                staff_guild_id: staff,
+            }
+        }
+        _ => {
+            let id = match payload.guild_id {
+                Some(id) => id,
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "success": false,
+                            "error": "guild_id is required for single mode"
+                        })),
+                    );
+                }
+            };
+            ServerMode::Single { guild_id: id }
+        }
+    };
+
+    let bot_config = BotConfig {
+        token: payload.token,
+        mode,
+        status: payload.bot_status,
+        welcome_message: payload.welcome_message,
+        close_message: payload.close_message,
+        typing_proxy_from_user: payload.typing_proxy_from_user,
+        typing_proxy_from_staff: payload.typing_proxy_from_staff,
+        enable_rustmail_logs: payload.enable_rustmail_logs,
+        enable_discord_logs: payload.enable_discord_logs,
+        enable_features: payload.enable_features,
+        enable_panel: payload.enable_panel,
+        client_id: payload.client_id.unwrap_or(0),
+        client_secret: payload.client_secret.unwrap_or_default(),
+        redirect_url: payload.redirect_url.unwrap_or_default(),
+        timezone: payload.timezone.parse().unwrap_or(chrono_tz::UTC),
+        logs_channel_id: payload.logs_channel_id,
+        features_channel_id: payload.features_channel_id,
+        ip: None,
+        panel_super_admin_users: payload.panel_super_admin_users,
+        panel_super_admin_roles: vec![],
+    };
+
+    let config = Config {
+        bot: bot_config,
+        command: CommandConfig {
+            prefix: payload.command_prefix,
+        },
+        thread: ThreadConfig {
+            inbox_category_id: payload.inbox_category_id,
+            embedded_message: payload.embedded_message,
+            user_message_color: payload.user_message_color,
+            staff_message_color: payload.staff_message_color,
+            system_message_color: payload.system_message_color,
+            block_quote: payload.block_quote,
+            time_to_close_thread: payload.time_to_close_thread,
+            create_ticket_by_create_channel: payload.create_ticket_by_create_channel,
+            close_on_leave: payload.close_on_leave,
+            auto_archive_duration: payload.auto_archive_duration,
+        },
+        language: LanguageConfig {
+            default_language: payload.default_language.clone(),
+            fallback_language: payload.fallback_language,
+            supported_languages: vec![payload.default_language],
+        },
+        error_handling: ErrorHandlingConfig::default(),
+        notifications: NotificationsConfig::default(),
+        reminders: ReminderConfig::default(),
+        logs: LogsConfig::default(),
+        db_pool: None,
+        error_handler: None,
+        thread_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    };
+
+    if let Err(e) = validate_config(&config) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "success": false, "error": e })),
+        );
+    }
+
+    let config_path = resolve_config_path("config.toml");
+
+    if let Err(e) = save_config_with_backup(&config, &config_path).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "success": false, "error": e })),
+        );
+    }
+
+    let mut state = setup_state.lock().await;
+    state.step = crate::setup::state::SetupStep::Review;
+
+    (StatusCode::OK, Json(serde_json::json!({ "success": true })))
+}

--- a/crates/rustmail/src/setup/handlers/status.rs
+++ b/crates/rustmail/src/setup/handlers/status.rs
@@ -1,0 +1,29 @@
+use crate::setup::state::SharedSetupState;
+use axum::Json;
+use axum::extract::State;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct SetupStatusResponse {
+    pub setup_required: bool,
+    pub step: String,
+    pub token_prefill: Option<String>,
+}
+
+pub async fn handle_setup_status(
+    State(setup_state): State<SharedSetupState>,
+) -> Json<SetupStatusResponse> {
+    let state = setup_state.lock().await;
+
+    let step = format!("{:?}", state.step).to_lowercase();
+
+    let token_prefill = std::env::var("RUSTMAIL_BOT_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty());
+
+    Json(SetupStatusResponse {
+        setup_required: true,
+        step,
+        token_prefill,
+    })
+}

--- a/crates/rustmail/src/setup/handlers/validate.rs
+++ b/crates/rustmail/src/setup/handlers/validate.rs
@@ -1,0 +1,268 @@
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct ValidateTokenRequest {
+    pub token: String,
+}
+
+#[derive(Deserialize)]
+pub struct ValidateGuildRequest {
+    pub token: String,
+    pub guild_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct ValidateChannelRequest {
+    pub token: String,
+    pub guild_id: String,
+    pub channel_id: String,
+}
+
+#[derive(Serialize)]
+pub struct BotInfo {
+    pub id: String,
+    pub username: String,
+    pub avatar: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct GuildInfo {
+    pub id: String,
+    pub name: String,
+    pub icon: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ChannelInfo {
+    pub id: String,
+    pub name: String,
+    pub kind: u8,
+}
+
+#[derive(Serialize)]
+pub struct ValidateTokenResponse {
+    pub valid: bool,
+    pub bot: Option<BotInfo>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidateGuildResponse {
+    pub valid: bool,
+    pub guild: Option<GuildInfo>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidateChannelResponse {
+    pub valid: bool,
+    pub channel: Option<ChannelInfo>,
+    pub error: Option<String>,
+}
+
+pub async fn handle_validate_token(Json(payload): Json<ValidateTokenRequest>) -> impl IntoResponse {
+    let client = Client::new();
+
+    let resp = match client
+        .get("https://discord.com/api/v10/users/@me")
+        .header("Authorization", format!("Bot {}", payload.token))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(ValidateTokenResponse {
+                    valid: false,
+                    bot: None,
+                    error: Some("Network error reaching Discord API".to_string()),
+                }),
+            );
+        }
+    };
+
+    if !resp.status().is_success() {
+        return (
+            StatusCode::OK,
+            Json(ValidateTokenResponse {
+                valid: false,
+                bot: None,
+                error: Some("Invalid token".to_string()),
+            }),
+        );
+    }
+
+    let data: serde_json::Value = match resp.json().await {
+        Ok(d) => d,
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(ValidateTokenResponse {
+                    valid: false,
+                    bot: None,
+                    error: Some("Failed to parse Discord response".to_string()),
+                }),
+            );
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(ValidateTokenResponse {
+            valid: true,
+            bot: Some(BotInfo {
+                id: data["id"].as_str().unwrap_or("").to_string(),
+                username: data["username"].as_str().unwrap_or("").to_string(),
+                avatar: data["avatar"].as_str().map(|s| s.to_string()),
+            }),
+            error: None,
+        }),
+    )
+}
+
+pub async fn handle_validate_guild(Json(payload): Json<ValidateGuildRequest>) -> impl IntoResponse {
+    let client = Client::new();
+
+    let resp = match client
+        .get(format!(
+            "https://discord.com/api/v10/guilds/{}",
+            payload.guild_id
+        ))
+        .header("Authorization", format!("Bot {}", payload.token))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(ValidateGuildResponse {
+                    valid: false,
+                    guild: None,
+                    error: Some("Network error reaching Discord API".to_string()),
+                }),
+            );
+        }
+    };
+
+    if !resp.status().is_success() {
+        return (
+            StatusCode::OK,
+            Json(ValidateGuildResponse {
+                valid: false,
+                guild: None,
+                error: Some("Guild not found or bot is not a member".to_string()),
+            }),
+        );
+    }
+
+    let data: serde_json::Value = match resp.json().await {
+        Ok(d) => d,
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(ValidateGuildResponse {
+                    valid: false,
+                    guild: None,
+                    error: Some("Failed to parse Discord response".to_string()),
+                }),
+            );
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(ValidateGuildResponse {
+            valid: true,
+            guild: Some(GuildInfo {
+                id: data["id"].as_str().unwrap_or("").to_string(),
+                name: data["name"].as_str().unwrap_or("").to_string(),
+                icon: data["icon"].as_str().map(|s| s.to_string()),
+            }),
+            error: None,
+        }),
+    )
+}
+
+pub async fn handle_validate_channel(
+    Json(payload): Json<ValidateChannelRequest>,
+) -> impl IntoResponse {
+    let client = Client::new();
+
+    let resp = match client
+        .get(format!(
+            "https://discord.com/api/v10/channels/{}",
+            payload.channel_id
+        ))
+        .header("Authorization", format!("Bot {}", payload.token))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(ValidateChannelResponse {
+                    valid: false,
+                    channel: None,
+                    error: Some("Network error reaching Discord API".to_string()),
+                }),
+            );
+        }
+    };
+
+    if !resp.status().is_success() {
+        return (
+            StatusCode::OK,
+            Json(ValidateChannelResponse {
+                valid: false,
+                channel: None,
+                error: Some("Channel not found or bot has no access".to_string()),
+            }),
+        );
+    }
+
+    let data: serde_json::Value = match resp.json().await {
+        Ok(d) => d,
+        Err(_) => {
+            return (
+                StatusCode::OK,
+                Json(ValidateChannelResponse {
+                    valid: false,
+                    channel: None,
+                    error: Some("Failed to parse Discord response".to_string()),
+                }),
+            );
+        }
+    };
+
+    let guild_id = data["guild_id"].as_str().unwrap_or("");
+    if guild_id != payload.guild_id {
+        return (
+            StatusCode::OK,
+            Json(ValidateChannelResponse {
+                valid: false,
+                channel: None,
+                error: Some("Channel does not belong to the specified guild".to_string()),
+            }),
+        );
+    }
+
+    (
+        StatusCode::OK,
+        Json(ValidateChannelResponse {
+            valid: true,
+            channel: Some(ChannelInfo {
+                id: data["id"].as_str().unwrap_or("").to_string(),
+                name: data["name"].as_str().unwrap_or("").to_string(),
+                kind: data["type"].as_u64().unwrap_or(0) as u8,
+            }),
+            error: None,
+        }),
+    )
+}

--- a/crates/rustmail/src/setup/handlers/validate.rs
+++ b/crates/rustmail/src/setup/handlers/validate.rs
@@ -22,6 +22,12 @@ pub struct ValidateChannelRequest {
     pub channel_id: String,
 }
 
+#[derive(Deserialize)]
+pub struct ValidateOAuth2Request {
+    pub client_id: String,
+    pub client_secret: String,
+}
+
 #[derive(Serialize)]
 pub struct BotInfo {
     pub id: String,
@@ -265,4 +271,56 @@ pub async fn handle_validate_channel(
             error: None,
         }),
     )
+}
+
+pub async fn handle_validate_oauth2(
+    Json(payload): Json<ValidateOAuth2Request>,
+) -> impl IntoResponse {
+    let client = Client::new();
+
+    let res = client
+        .post("https://discord.com/api/v10/oauth2/token")
+        .basic_auth(&payload.client_id, Some(&payload.client_secret))
+        .form(&[("grant_type", "client_credentials"), ("scope", "identify")])
+        .send()
+        .await;
+
+    match res {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({ "valid": true, "error": None::<String> })),
+                )
+            } else {
+                let err_msg = match resp.json::<serde_json::Value>().await {
+                    Ok(json) => {
+                        if let Some(desc) = json.get("error_description").and_then(|d| d.as_str()) {
+                            desc.to_string()
+                        } else if let Some(err) = json.get("error").and_then(|e| e.as_str()) {
+                            err.to_string()
+                        } else {
+                            "Invalid credentials".to_string()
+                        }
+                    }
+                    Err(_) => "Invalid credentials".to_string(),
+                };
+
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "valid": false,
+                        "error": err_msg
+                    })),
+                )
+            }
+        }
+        Err(e) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "valid": false,
+                "error": format!("Network error: {}", e)
+            })),
+        ),
+    }
 }

--- a/crates/rustmail/src/setup/mod.rs
+++ b/crates/rustmail/src/setup/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod router;
+pub mod state;

--- a/crates/rustmail/src/setup/router.rs
+++ b/crates/rustmail/src/setup/router.rs
@@ -1,6 +1,6 @@
 use crate::setup::handlers::{
-    handle_setup_save, handle_setup_status, handle_validate_channel, handle_validate_guild,
-    handle_validate_token,
+    handle_setup_restart, handle_setup_save, handle_setup_status, handle_validate_channel,
+    handle_validate_guild, handle_validate_oauth2, handle_validate_token,
 };
 use crate::setup::state::SharedSetupState;
 use axum::Router;
@@ -12,6 +12,8 @@ pub fn create_setup_router(setup_state: SharedSetupState) -> Router {
         .route("/api/setup/validate-token", post(handle_validate_token))
         .route("/api/setup/validate-guild", post(handle_validate_guild))
         .route("/api/setup/validate-channel", post(handle_validate_channel))
+        .route("/api/setup/validate-oauth2", post(handle_validate_oauth2))
         .route("/api/setup/save", post(handle_setup_save))
+        .route("/api/setup/restart", post(handle_setup_restart))
         .with_state(setup_state)
 }

--- a/crates/rustmail/src/setup/router.rs
+++ b/crates/rustmail/src/setup/router.rs
@@ -1,0 +1,17 @@
+use crate::setup::handlers::{
+    handle_setup_save, handle_setup_status, handle_validate_channel, handle_validate_guild,
+    handle_validate_token,
+};
+use crate::setup::state::SharedSetupState;
+use axum::Router;
+use axum::routing::{get, post};
+
+pub fn create_setup_router(setup_state: SharedSetupState) -> Router {
+    Router::new()
+        .route("/api/setup/status", get(handle_setup_status))
+        .route("/api/setup/validate-token", post(handle_validate_token))
+        .route("/api/setup/validate-guild", post(handle_validate_guild))
+        .route("/api/setup/validate-channel", post(handle_validate_channel))
+        .route("/api/setup/save", post(handle_setup_save))
+        .with_state(setup_state)
+}

--- a/crates/rustmail/src/setup/state.rs
+++ b/crates/rustmail/src/setup/state.rs
@@ -4,6 +4,7 @@ use rustmail_types::{
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio::sync::mpsc::Sender;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum SetupStep {
@@ -46,6 +47,7 @@ pub struct PartialConfig {
 pub struct SetupState {
     pub step: SetupStep,
     pub config: PartialConfig,
+    pub shutdown_tx: Option<Sender<()>>,
 }
 
 impl SetupState {
@@ -53,6 +55,7 @@ impl SetupState {
         Self {
             step: SetupStep::Token,
             config: PartialConfig::default(),
+            shutdown_tx: None,
         }
     }
 }

--- a/crates/rustmail/src/setup/state.rs
+++ b/crates/rustmail/src/setup/state.rs
@@ -1,0 +1,64 @@
+use rustmail_types::{
+    BotConfig, CommandConfig, ErrorHandlingConfig, LanguageConfig, LogsConfig, NotificationsConfig,
+    ReminderConfig, ServerMode, ThreadConfig,
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SetupStep {
+    Token,
+    ServerMode,
+    ThreadConfig,
+    PanelConfig,
+    Language,
+    Review,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PartialConfig {
+    pub token: Option<String>,
+    pub bot_id: Option<u64>,
+    pub bot_username: Option<String>,
+    pub bot_avatar: Option<String>,
+    pub server_mode: Option<ServerMode>,
+    pub bot_status: Option<String>,
+    pub welcome_message: Option<String>,
+    pub close_message: Option<String>,
+    pub typing_proxy_from_user: Option<bool>,
+    pub typing_proxy_from_staff: Option<bool>,
+    pub thread: Option<ThreadConfig>,
+    pub command: Option<CommandConfig>,
+    pub enable_panel: Option<bool>,
+    pub client_id: Option<u64>,
+    pub client_secret: Option<String>,
+    pub redirect_url: Option<String>,
+    pub panel_super_admin_users: Option<Vec<u64>>,
+    pub language: Option<LanguageConfig>,
+    pub enable_rustmail_logs: Option<bool>,
+    pub enable_discord_logs: Option<bool>,
+    pub logs_channel_id: Option<u64>,
+    pub enable_features: Option<bool>,
+    pub features_channel_id: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct SetupState {
+    pub step: SetupStep,
+    pub config: PartialConfig,
+}
+
+impl SetupState {
+    pub fn new() -> Self {
+        Self {
+            step: SetupStep::Token,
+            config: PartialConfig::default(),
+        }
+    }
+}
+
+pub type SharedSetupState = Arc<Mutex<SetupState>>;
+
+pub fn new_setup_state() -> SharedSetupState {
+    Arc::new(Mutex::new(SetupState::new()))
+}

--- a/crates/rustmail/src/setup/state.rs
+++ b/crates/rustmail/src/setup/state.rs
@@ -1,7 +1,4 @@
-use rustmail_types::{
-    BotConfig, CommandConfig, ErrorHandlingConfig, LanguageConfig, LogsConfig, NotificationsConfig,
-    ReminderConfig, ServerMode, ThreadConfig,
-};
+use rustmail_types::{CommandConfig, LanguageConfig, ServerMode, ThreadConfig};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::Sender;

--- a/crates/rustmail/src/utils/message/message_builder.rs
+++ b/crates/rustmail/src/utils/message/message_builder.rs
@@ -405,7 +405,7 @@ impl<'a> MessageBuilder<'a> {
         let message = match target {
             MessageTarget::Channel(channel_id) => {
                 let db_thread_id =
-                    match get_thread_by_channel_id(&channel_id.to_string(), &pool).await {
+                    match get_thread_by_channel_id(&channel_id.to_string(), pool).await {
                         Some(thread) => Some(thread.id.clone()),
                         None => None,
                     };
@@ -420,7 +420,7 @@ impl<'a> MessageBuilder<'a> {
                 Ok(message)
             }
             MessageTarget::User(user_id) => {
-                let db_thread_id = match get_thread_by_user_id(user_id, &pool).await {
+                let db_thread_id = match get_thread_by_user_id(user_id, pool).await {
                     Some(thread) => Some(thread.id.clone()),
                     None => None,
                 };
@@ -440,7 +440,7 @@ impl<'a> MessageBuilder<'a> {
             }
             MessageTarget::Reply(original_message) => {
                 let db_thread_id =
-                    match get_thread_by_channel_id(&original_message.channel_id.to_string(), &pool)
+                    match get_thread_by_channel_id(&original_message.channel_id.to_string(), pool)
                         .await
                     {
                         Some(thread) => Some(thread.id.clone()),
@@ -469,13 +469,13 @@ impl<'a> MessageBuilder<'a> {
 
         if to_be_recorded {
             let _ = insert_staff_message(
-                &self.ctx,
+                self.ctx,
                 &message,
                 dm_message_id,
                 &thread_id.unwrap_or_default(),
                 self.bot_user_id,
                 false,
-                &pool,
+                pool,
                 self.config,
                 None,
             )
@@ -572,7 +572,7 @@ impl<'a> MessageBuilder<'a> {
             }
         }
 
-        if self.attachments.is_empty() == false {
+        if !self.attachments.is_empty() {
             for attachment in &self.attachments {
                 message = message.add_file(attachment.clone());
             }
@@ -837,7 +837,7 @@ impl<'a> StaffReply<'a> {
 
         let dm_id_opt = dm_msg_opt.as_ref().map(|m| m.id.to_string());
         if let Err(e) = insert_staff_message(
-            &self.ctx,
+            self.ctx,
             &thread_msg,
             dm_id_opt,
             &self.thread_id,
@@ -905,7 +905,7 @@ impl<'a> StaffReply<'a> {
 
         let dm_id_opt = dm_msg_opt.as_ref().map(|m| m.id.to_string());
         if let Err(e) = insert_staff_message(
-            &self.ctx,
+            self.ctx,
             &thread_msg,
             dm_id_opt,
             &self.thread_id,

--- a/crates/rustmail/src/utils/thread/send_to_thread.rs
+++ b/crates/rustmail/src/utils/thread/send_to_thread.rs
@@ -132,7 +132,7 @@ pub async fn send_to_thread(
         }
     };
 
-    let mut ticket_status = match get_thread_status(&thread_id.clone(), &pool).await {
+    let mut ticket_status = match get_thread_status(&thread_id.clone(), pool).await {
         Some(status) => status,
         None => {
             return Err(validation_failed("Failed to get thread status"));

--- a/crates/rustmail_panel/Cargo.toml
+++ b/crates/rustmail_panel/Cargo.toml
@@ -21,3 +21,4 @@ ammonia = "4.1.2"
 pulldown-cmark = "0.13.4"
 chrono = { version = "0.4.45", features = ["serde", "wasmbind"] }
 chrono-tz = { version = "0.10.4", features = ["serde"] }
+gloo-timers = { version = "0.4.0", features = ["futures"] }

--- a/crates/rustmail_panel/src/components/mod.rs
+++ b/crates/rustmail_panel/src/components/mod.rs
@@ -7,5 +7,6 @@ pub mod home;
 pub mod language_switcher;
 pub mod logout_button;
 pub mod navbar;
+pub mod setup_detector;
 pub mod statistics;
 pub mod ticket;

--- a/crates/rustmail_panel/src/components/mod.rs
+++ b/crates/rustmail_panel/src/components/mod.rs
@@ -10,3 +10,4 @@ pub mod navbar;
 pub mod setup_detector;
 pub mod statistics;
 pub mod ticket;
+pub mod wizard;

--- a/crates/rustmail_panel/src/components/setup_detector.rs
+++ b/crates/rustmail_panel/src/components/setup_detector.rs
@@ -5,6 +5,7 @@ use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct SetupStatusResponse {
     pub setup_required: bool,

--- a/crates/rustmail_panel/src/components/setup_detector.rs
+++ b/crates/rustmail_panel/src/components/setup_detector.rs
@@ -38,13 +38,6 @@ pub fn setup_detector() -> Html {
         });
     }
 
-    if *is_checking {
-        html! {
-            <div class="flex items-center justify-center min-h-screen bg-slate-900 text-white">
-                <div class="text-gray-400 animate-pulse">{ "Checking setup mode..." }</div>
-            </div>
-        }
-    } else {
-        html! {}
-    }
+    let _ = is_checking;
+    html! {}
 }

--- a/crates/rustmail_panel/src/components/setup_detector.rs
+++ b/crates/rustmail_panel/src/components/setup_detector.rs
@@ -1,0 +1,49 @@
+use crate::router::Route;
+use gloo_net::http::Request;
+use serde::Deserialize;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+use yew_router::prelude::*;
+
+#[derive(Deserialize)]
+pub struct SetupStatusResponse {
+    pub setup_required: bool,
+    pub step: String,
+}
+
+#[function_component(SetupDetector)]
+pub fn setup_detector() -> Html {
+    let navigator = use_navigator();
+    let is_checking = use_state(|| true);
+
+    {
+        let navigator = navigator.clone();
+        let is_checking = is_checking.clone();
+
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                if let Ok(resp) = Request::get("/api/setup/status").send().await {
+                    if let Ok(status) = resp.json::<SetupStatusResponse>().await {
+                        if status.setup_required {
+                            if let Some(nav) = navigator {
+                                nav.push(&Route::Setup);
+                            }
+                        }
+                    }
+                }
+                is_checking.set(false);
+            });
+            || ()
+        });
+    }
+
+    if *is_checking {
+        html! {
+            <div class="flex items-center justify-center min-h-screen bg-slate-900 text-white">
+                <div class="text-gray-400 animate-pulse">{ "Checking setup mode..." }</div>
+            </div>
+        }
+    } else {
+        html! {}
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/layout.rs
+++ b/crates/rustmail_panel/src/components/wizard/layout.rs
@@ -7,7 +7,7 @@ use yew::prelude::*;
 pub struct LayoutProps {
     pub current_step: usize,
     pub total_steps: usize,
-    pub step_names: Vec<&'static str>,
+    pub step_names: Vec<String>,
     pub title: String,
     pub description: String,
     pub children: Children,

--- a/crates/rustmail_panel/src/components/wizard/layout.rs
+++ b/crates/rustmail_panel/src/components/wizard/layout.rs
@@ -1,0 +1,58 @@
+use crate::components::wizard::progress_bar::ProgressBar;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct LayoutProps {
+    pub current_step: usize,
+    pub total_steps: usize,
+    pub step_names: Vec<&'static str>,
+    pub title: String,
+    pub description: String,
+    pub children: Children,
+}
+
+#[function_component(WizardLayout)]
+pub fn wizard_layout(props: &LayoutProps) -> Html {
+    html! {
+        <div class="min-h-screen bg-slate-950 flex flex-col items-center justify-center p-4 sm:p-8 text-white font-sans">
+            <div class="w-full max-w-4xl flex flex-col gap-8">
+
+                // Header with logo and title
+                <div class="flex flex-col items-center text-center gap-4">
+                    <div class="w-16 h-16 bg-indigo-600 rounded-2xl flex items-center justify-center shadow-lg shadow-indigo-500/20">
+                        <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                        </svg>
+                    </div>
+                    <div>
+                        <h1 class="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
+                            { "Rustmail Setup" }
+                        </h1>
+                        <p class="text-gray-400 mt-2">{ "Configure your Discord modmail bot in a few easy steps" }</p>
+                    </div>
+                </div>
+
+                // Progress Bar
+                <ProgressBar
+                    current_step={props.current_step}
+                    total_steps={props.total_steps}
+                    step_names={props.step_names.clone()}
+                />
+
+                // Main Content Card
+                <div class="bg-slate-900 border border-slate-800 rounded-2xl shadow-xl overflow-hidden flex flex-col">
+                    <div class="px-6 py-5 sm:px-8 sm:py-6 border-b border-slate-800 bg-slate-900/50">
+                        <h2 class="text-xl font-semibold text-white">{ &props.title }</h2>
+                        <p class="text-sm text-gray-400 mt-1">{ &props.description }</p>
+                    </div>
+
+                    <div class="p-6 sm:p-8 flex-1">
+                        { for props.children.iter() }
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/layout.rs
+++ b/crates/rustmail_panel/src/components/wizard/layout.rs
@@ -1,4 +1,6 @@
+use crate::components::language_switcher::LanguageSwitcher;
 use crate::components::wizard::progress_bar::ProgressBar;
+use crate::i18n::yew::use_translation;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
@@ -13,8 +15,15 @@ pub struct LayoutProps {
 
 #[function_component(WizardLayout)]
 pub fn wizard_layout(props: &LayoutProps) -> Html {
+    let (i18n, _) = use_translation();
     html! {
-        <div class="min-h-screen bg-slate-950 flex flex-col items-center justify-center p-4 sm:p-8 text-white font-sans">
+        <div class="min-h-screen bg-slate-950 flex flex-col items-center justify-center p-4 sm:p-8 text-white font-sans relative">
+
+            // Language Switcher in top right corner
+            <div class="absolute top-4 right-4 sm:top-8 sm:right-8 z-50">
+                <LanguageSwitcher placement="nav" />
+            </div>
+
             <div class="w-full max-w-4xl flex flex-col gap-8">
 
                 // Header with logo and title
@@ -27,9 +36,9 @@ pub fn wizard_layout(props: &LayoutProps) -> Html {
                     </div>
                     <div>
                         <h1 class="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400">
-                            { "Rustmail Setup" }
+                            { i18n.t("wizard.title") }
                         </h1>
-                        <p class="text-gray-400 mt-2">{ "Configure your Discord modmail bot in a few easy steps" }</p>
+                        <p class="text-gray-400 mt-2">{ i18n.t("wizard.progress") }</p>
                     </div>
                 </div>
 

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -1,0 +1,2 @@
+pub mod layout;
+pub mod progress_bar;

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -4,4 +4,5 @@ pub mod step1_token;
 pub mod step2_guilds;
 pub mod step3_thread;
 pub mod step4_panel;
+pub mod step5_language;
 pub mod types;

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -3,4 +3,5 @@ pub mod progress_bar;
 pub mod step1_token;
 pub mod step2_guilds;
 pub mod step3_thread;
+pub mod step4_panel;
 pub mod types;

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -5,4 +5,5 @@ pub mod step2_guilds;
 pub mod step3_thread;
 pub mod step4_panel;
 pub mod step5_language;
+pub mod step6_review;
 pub mod types;

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -1,2 +1,4 @@
 pub mod layout;
 pub mod progress_bar;
+pub mod step1_token;
+pub mod types;

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -2,4 +2,5 @@ pub mod layout;
 pub mod progress_bar;
 pub mod step1_token;
 pub mod step2_guilds;
+pub mod step3_thread;
 pub mod types;

--- a/crates/rustmail_panel/src/components/wizard/mod.rs
+++ b/crates/rustmail_panel/src/components/wizard/mod.rs
@@ -1,4 +1,5 @@
 pub mod layout;
 pub mod progress_bar;
 pub mod step1_token;
+pub mod step2_guilds;
 pub mod types;

--- a/crates/rustmail_panel/src/components/wizard/progress_bar.rs
+++ b/crates/rustmail_panel/src/components/wizard/progress_bar.rs
@@ -4,7 +4,7 @@ use yew::prelude::*;
 pub struct ProgressBarProps {
     pub current_step: usize,
     pub total_steps: usize,
-    pub step_names: Vec<&'static str>,
+    pub step_names: Vec<String>,
 }
 
 #[function_component(ProgressBar)]

--- a/crates/rustmail_panel/src/components/wizard/progress_bar.rs
+++ b/crates/rustmail_panel/src/components/wizard/progress_bar.rs
@@ -1,0 +1,51 @@
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct ProgressBarProps {
+    pub current_step: usize,
+    pub total_steps: usize,
+    pub step_names: Vec<&'static str>,
+}
+
+#[function_component(ProgressBar)]
+pub fn progress_bar(props: &ProgressBarProps) -> Html {
+    let progress_percent = if props.total_steps > 1 {
+        (props.current_step as f64 / (props.total_steps - 1) as f64) * 100.0
+    } else {
+        100.0
+    };
+
+    html! {
+        <div class="w-full mb-8">
+            <div class="flex justify-between items-center mb-2 px-1">
+                {
+                    for props.step_names.iter().enumerate().map(|(idx, name)| {
+                        let is_active = idx == props.current_step;
+                        let is_past = idx < props.current_step;
+
+                        let text_color = if is_active {
+                            "text-indigo-400 font-semibold"
+                        } else if is_past {
+                            "text-gray-300"
+                        } else {
+                            "text-gray-600"
+                        };
+
+                        html! {
+                            <div class={classes!("text-xs", "sm:text-sm", "transition-colors", "duration-300", text_color)}>
+                                { name }
+                            </div>
+                        }
+                    })
+                }
+            </div>
+
+            <div class="h-2 w-full bg-slate-800 rounded-full overflow-hidden">
+                <div
+                    class="h-full bg-indigo-500 transition-all duration-500 ease-out"
+                    style={format!("width: {}%", progress_percent)}
+                ></div>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step1_token.rs
+++ b/crates/rustmail_panel/src/components/wizard/step1_token.rs
@@ -1,0 +1,172 @@
+use crate::components::wizard::types::{ValidateTokenRequest, ValidateTokenResponse, WizardData};
+use gloo_net::http::Request;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct Step1Props {
+    pub data: WizardData,
+    pub on_update: Callback<WizardData>,
+    pub on_next: Callback<()>,
+}
+
+#[function_component(Step1Token)]
+pub fn step1_token(props: &Step1Props) -> Html {
+    let token = use_state(|| props.data.token.clone());
+    let is_validating = use_state(|| false);
+    let validation_result = use_state(|| None::<ValidateTokenResponse>);
+
+    let on_token_change = {
+        let token = token.clone();
+        let validation_result = validation_result.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            token.set(input.value());
+            validation_result.set(None); // Reset validation on typing
+        })
+    };
+
+    let validate_token = {
+        let token = token.clone();
+        let is_validating = is_validating.clone();
+        let validation_result = validation_result.clone();
+
+        Callback::from(move |_| {
+            let token_val = (*token).clone();
+            if token_val.trim().is_empty() {
+                return;
+            }
+
+            let is_validating = is_validating.clone();
+            let validation_result = validation_result.clone();
+
+            is_validating.set(true);
+
+            spawn_local(async move {
+                let req_body = ValidateTokenRequest { token: token_val };
+
+                let res = Request::post("/api/setup/validate-token")
+                    .json(&req_body)
+                    .unwrap()
+                    .send()
+                    .await;
+
+                match res {
+                    Ok(resp) => {
+                        if let Ok(data) = resp.json::<ValidateTokenResponse>().await {
+                            validation_result.set(Some(data));
+                        } else {
+                            validation_result.set(Some(ValidateTokenResponse {
+                                valid: false,
+                                bot: None,
+                                error: Some("Invalid response from server".to_string()),
+                            }));
+                        }
+                    }
+                    Err(_) => {
+                        validation_result.set(Some(ValidateTokenResponse {
+                            valid: false,
+                            bot: None,
+                            error: Some("Network error".to_string()),
+                        }));
+                    }
+                }
+
+                is_validating.set(false);
+            });
+        })
+    };
+
+    let on_next = {
+        let props_on_next = props.on_next.clone();
+        let props_on_update = props.on_update.clone();
+        let token = token.clone();
+        let current_data = props.data.clone();
+
+        Callback::from(move |_| {
+            let mut new_data = current_data.clone();
+            new_data.token = (*token).clone();
+            props_on_update.emit(new_data);
+            props_on_next.emit(());
+        })
+    };
+
+    let is_valid = validation_result.as_ref().map(|r| r.valid).unwrap_or(false);
+
+    html! {
+        <div class="flex flex-col gap-6 animate-fade-in">
+            <div class="flex flex-col gap-2">
+                <label class="text-sm font-medium text-gray-300">{ "Discord Bot Token" }</label>
+                <div class="flex gap-3">
+                    <input
+                        type="password"
+                        class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="Paste your bot token here..."
+                        value={(*token).clone()}
+                        onchange={on_token_change}
+                    />
+                    <button
+                        class="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[100px]"
+                        onclick={validate_token}
+                        disabled={*is_validating || token.trim().is_empty()}
+                    >
+                        if *is_validating {
+                            <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                            </svg>
+                        } else {
+                            { "Validate" }
+                        }
+                    </button>
+                </div>
+                <p class="text-xs text-gray-500 mt-1">
+                    { "You can get your token from the " }
+                    <a href="https://discord.com/developers/applications" target="_blank" class="text-indigo-400 hover:text-indigo-300 underline decoration-indigo-400/30 underline-offset-2">
+                        { "Discord Developer Portal" }
+                    </a>
+                    { "." }
+                </p>
+            </div>
+
+            // Validation Result Area
+            if let Some(result) = (*validation_result).as_ref() {
+                if result.valid {
+                    if let Some(bot) = &result.bot {
+                        <div class="bg-green-500/10 border border-green-500/20 rounded-xl p-4 flex items-center gap-4">
+                            if let Some(avatar) = &bot.avatar {
+                                <img src={format!("https://cdn.discordapp.com/avatars/{}/{}.png", bot.id, avatar)} class="w-12 h-12 rounded-full ring-2 ring-green-500/30" />
+                            } else {
+                                <div class="w-12 h-12 rounded-full bg-slate-800 flex items-center justify-center ring-2 ring-green-500/30">
+                                    <span class="text-gray-400 text-lg font-bold">{ bot.username.chars().next().unwrap_or('?') }</span>
+                                </div>
+                            }
+                            <div>
+                                <h3 class="text-green-400 font-medium">{ "Connected Successfully!" }</h3>
+                                <p class="text-sm text-gray-300">{ format!("Logged in as ") }<span class="font-semibold text-white">{ &bot.username }</span></p>
+                            </div>
+                        </div>
+                    }
+                } else if let Some(error) = &result.error {
+                    <div class="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+                        <svg class="w-5 h-5 text-red-400 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                        <div>
+                            <h3 class="text-red-400 font-medium">{ "Validation Failed" }</h3>
+                            <p class="text-sm text-red-300/80 mt-0.5">{ error }</p>
+                        </div>
+                    </div>
+                }
+            }
+
+            <div class="flex justify-end pt-4 mt-2 border-t border-slate-800/50">
+                <button
+                    class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onclick={on_next}
+                    disabled={!is_valid}
+                >
+                    { "Next Step" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step1_token.rs
+++ b/crates/rustmail_panel/src/components/wizard/step1_token.rs
@@ -1,4 +1,5 @@
 use crate::components::wizard::types::{ValidateTokenRequest, ValidateTokenResponse, WizardData};
+use crate::i18n::yew::use_translation;
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -12,6 +13,7 @@ pub struct Step1Props {
 
 #[function_component(Step1Token)]
 pub fn step1_token(props: &Step1Props) -> Html {
+    let (i18n, _) = use_translation();
     let token = use_state(|| props.data.token.clone());
     let is_validating = use_state(|| false);
     let validation_result = use_state(|| None::<ValidateTokenResponse>);
@@ -96,12 +98,12 @@ pub fn step1_token(props: &Step1Props) -> Html {
     html! {
         <div class="flex flex-col gap-6 animate-fade-in">
             <div class="flex flex-col gap-2">
-                <label class="text-sm font-medium text-gray-300">{ "Discord Bot Token" }</label>
+                <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step1.token_label") }</label>
                 <div class="flex gap-3">
                     <input
                         type="password"
                         class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="Paste your bot token here..."
+                        placeholder={i18n.t("wizard.steps.step1.token_placeholder")}
                         value={(*token).clone()}
                         onchange={on_token_change}
                     />
@@ -116,16 +118,12 @@ pub fn step1_token(props: &Step1Props) -> Html {
                                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                             </svg>
                         } else {
-                            { "Validate" }
+                            { i18n.t("wizard.common.verify") }
                         }
                     </button>
                 </div>
                 <p class="text-xs text-gray-500 mt-1">
-                    { "You can get your token from the " }
-                    <a href="https://discord.com/developers/applications" target="_blank" class="text-indigo-400 hover:text-indigo-300 underline decoration-indigo-400/30 underline-offset-2">
-                        { "Discord Developer Portal" }
-                    </a>
-                    { "." }
+                    { i18n.t("wizard.steps.step1.token_help") }
                 </p>
             </div>
 
@@ -142,8 +140,8 @@ pub fn step1_token(props: &Step1Props) -> Html {
                                 </div>
                             }
                             <div>
-                                <h3 class="text-green-400 font-medium">{ "Connected Successfully!" }</h3>
-                                <p class="text-sm text-gray-300">{ format!("Logged in as ") }<span class="font-semibold text-white">{ &bot.username }</span></p>
+                                <h3 class="text-green-400 font-medium">{ i18n.t("wizard.common.verified_success") }</h3>
+                                <p class="text-sm text-gray-300">{ i18n.t("wizard.steps.step1.logged_in_as") }<span class="font-semibold text-white">{ &bot.username }</span></p>
                             </div>
                         </div>
                     }
@@ -151,7 +149,7 @@ pub fn step1_token(props: &Step1Props) -> Html {
                     <div class="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
                         <svg class="w-5 h-5 text-red-400 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                         <div>
-                            <h3 class="text-red-400 font-medium">{ "Validation Failed" }</h3>
+                            <h3 class="text-red-400 font-medium">{ i18n.t("wizard.common.verification_failed") }</h3>
                             <p class="text-sm text-red-300/80 mt-0.5">{ error }</p>
                         </div>
                     </div>
@@ -164,7 +162,7 @@ pub fn step1_token(props: &Step1Props) -> Html {
                     onclick={on_next}
                     disabled={!is_valid}
                 >
-                    { "Next Step" }
+                    { i18n.t("wizard.common.next") }
                 </button>
             </div>
         </div>

--- a/crates/rustmail_panel/src/components/wizard/step2_guilds.rs
+++ b/crates/rustmail_panel/src/components/wizard/step2_guilds.rs
@@ -1,0 +1,323 @@
+use crate::components::wizard::types::{ValidateGuildRequest, ValidateGuildResponse, WizardData};
+use gloo_net::http::Request;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct Step2Props {
+    pub data: WizardData,
+    pub on_update: Callback<WizardData>,
+    pub on_next: Callback<()>,
+    pub on_prev: Callback<()>,
+}
+
+#[function_component(Step2Guilds)]
+pub fn step2_guilds(props: &Step2Props) -> Html {
+    let server_mode = use_state(|| {
+        if props.data.server_mode.is_empty() {
+            "single".to_string()
+        } else {
+            props.data.server_mode.clone()
+        }
+    });
+
+    let single_guild_id = use_state(|| props.data.single_guild_id.clone());
+    let community_guild_id = use_state(|| props.data.community_guild_id.clone());
+    let staff_guild_id = use_state(|| props.data.staff_guild_id.clone());
+
+    let single_guild_result = use_state(|| None::<ValidateGuildResponse>);
+    let community_guild_result = use_state(|| None::<ValidateGuildResponse>);
+    let staff_guild_result = use_state(|| None::<ValidateGuildResponse>);
+
+    let is_validating_single = use_state(|| false);
+    let is_validating_community = use_state(|| false);
+    let is_validating_staff = use_state(|| false);
+
+    let on_mode_change = {
+        let server_mode = server_mode.clone();
+        Callback::from(move |e: Event| {
+            let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+            server_mode.set(input.value());
+        })
+    };
+
+    let validate_guild =
+        |id_val: String,
+         token_val: String,
+         is_validating: UseStateHandle<bool>,
+         result_state: UseStateHandle<Option<ValidateGuildResponse>>| {
+            if id_val.trim().is_empty() {
+                return;
+            }
+
+            is_validating.set(true);
+
+            spawn_local(async move {
+                let req_body = ValidateGuildRequest {
+                    token: token_val,
+                    guild_id: id_val,
+                };
+
+                let res = Request::post("/api/setup/validate-guild")
+                    .json(&req_body)
+                    .unwrap()
+                    .send()
+                    .await;
+
+                match res {
+                    Ok(resp) => {
+                        if let Ok(data) = resp.json::<ValidateGuildResponse>().await {
+                            result_state.set(Some(data));
+                        } else {
+                            result_state.set(Some(ValidateGuildResponse {
+                                valid: false,
+                                guild: None,
+                                error: Some("Invalid response from server".to_string()),
+                            }));
+                        }
+                    }
+                    Err(_) => {
+                        result_state.set(Some(ValidateGuildResponse {
+                            valid: false,
+                            guild: None,
+                            error: Some("Network error".to_string()),
+                        }));
+                    }
+                }
+
+                is_validating.set(false);
+            });
+        };
+
+    let on_validate_single = {
+        let id = single_guild_id.clone();
+        let token = props.data.token.clone();
+        let is_validating = is_validating_single.clone();
+        let result_state = single_guild_result.clone();
+        Callback::from(move |_| {
+            validate_guild(
+                (*id).clone(),
+                token.clone(),
+                is_validating.clone(),
+                result_state.clone(),
+            )
+        })
+    };
+
+    let on_validate_community = {
+        let id = community_guild_id.clone();
+        let token = props.data.token.clone();
+        let is_validating = is_validating_community.clone();
+        let result_state = community_guild_result.clone();
+        Callback::from(move |_| {
+            validate_guild(
+                (*id).clone(),
+                token.clone(),
+                is_validating.clone(),
+                result_state.clone(),
+            )
+        })
+    };
+
+    let on_validate_staff = {
+        let id = staff_guild_id.clone();
+        let token = props.data.token.clone();
+        let is_validating = is_validating_staff.clone();
+        let result_state = staff_guild_result.clone();
+        Callback::from(move |_| {
+            validate_guild(
+                (*id).clone(),
+                token.clone(),
+                is_validating.clone(),
+                result_state.clone(),
+            )
+        })
+    };
+
+    let is_valid = if *server_mode == "single" {
+        single_guild_result
+            .as_ref()
+            .map(|r| r.valid)
+            .unwrap_or(false)
+    } else {
+        community_guild_result
+            .as_ref()
+            .map(|r| r.valid)
+            .unwrap_or(false)
+            && staff_guild_result
+                .as_ref()
+                .map(|r| r.valid)
+                .unwrap_or(false)
+    };
+
+    let on_next = {
+        let props_on_next = props.on_next.clone();
+        let props_on_update = props.on_update.clone();
+        let server_mode = server_mode.clone();
+        let single_guild_id = single_guild_id.clone();
+        let community_guild_id = community_guild_id.clone();
+        let staff_guild_id = staff_guild_id.clone();
+        let current_data = props.data.clone();
+
+        Callback::from(move |_| {
+            let mut new_data = current_data.clone();
+            new_data.server_mode = (*server_mode).clone();
+            new_data.single_guild_id = (*single_guild_id).clone();
+            new_data.community_guild_id = (*community_guild_id).clone();
+            new_data.staff_guild_id = (*staff_guild_id).clone();
+            props_on_update.emit(new_data);
+            props_on_next.emit(());
+        })
+    };
+
+    let on_prev = {
+        let props_on_prev = props.on_prev.clone();
+        Callback::from(move |_| {
+            props_on_prev.emit(());
+        })
+    };
+
+    let render_guild_input = |label: &str,
+                              desc: &str,
+                              state: UseStateHandle<String>,
+                              result: UseStateHandle<Option<ValidateGuildResponse>>,
+                              is_validating: UseStateHandle<bool>,
+                              on_validate: Callback<MouseEvent>| {
+        let on_change = {
+            let state = state.clone();
+            let result = result.clone();
+            Callback::from(move |e: Event| {
+                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                state.set(input.value());
+                result.set(None);
+            })
+        };
+
+        html! {
+            <div class="flex flex-col gap-2 mt-4 bg-slate-800/30 p-4 rounded-xl border border-slate-700/50">
+                <label class="text-sm font-medium text-gray-300">{ label }</label>
+                <p class="text-xs text-gray-500 mb-2">{ desc }</p>
+                <div class="flex gap-3">
+                    <input
+                        type="text"
+                        class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="e.g. 123456789012345678"
+                        value={(*state).clone()}
+                        onchange={on_change}
+                    />
+                    <button
+                        class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[100px]"
+                        onclick={on_validate}
+                        disabled={*is_validating || state.trim().is_empty()}
+                    >
+                        if *is_validating {
+                            <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+                        } else {
+                            { "Validate" }
+                        }
+                    </button>
+                </div>
+
+                if let Some(res) = (*result).as_ref() {
+                    if res.valid {
+                        if let Some(guild) = &res.guild {
+                            <div class="mt-3 flex items-center gap-3 text-sm text-green-400">
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                { format!("Found server: {}", guild.name) }
+                            </div>
+                        }
+                    } else if let Some(error) = &res.error {
+                        <div class="mt-3 flex items-center gap-3 text-sm text-red-400">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                            { error }
+                        </div>
+                    }
+                }
+            </div>
+        }
+    };
+
+    html! {
+        <div class="flex flex-col gap-6 animate-fade-in">
+            <div class="flex flex-col gap-4">
+                <label class="text-sm font-medium text-gray-300">{ "Select Server Mode" }</label>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <label class={format!("relative flex cursor-pointer rounded-lg border bg-slate-900/50 p-4 shadow-sm focus:outline-none transition-all {}",
+                        if *server_mode == "single" { "border-indigo-500 ring-1 ring-indigo-500" } else { "border-slate-700 hover:border-slate-600" })}>
+                        <input type="radio" name="server_mode" value="single" class="sr-only" checked={*server_mode == "single"} onchange={on_mode_change.clone()} />
+                        <span class="flex flex-1">
+                            <span class="flex flex-col">
+                                <span class="block text-sm font-medium text-white">{ "Single Server" }</span>
+                                <span class="mt-1 flex items-center text-sm text-gray-400">{ "Community and staff use the same server." }</span>
+                            </span>
+                        </span>
+                        if *server_mode == "single" {
+                            <svg class="h-5 w-5 text-indigo-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" /></svg>
+                        }
+                    </label>
+
+                    <label class={format!("relative flex cursor-pointer rounded-lg border bg-slate-900/50 p-4 shadow-sm focus:outline-none transition-all {}",
+                        if *server_mode == "dual" { "border-indigo-500 ring-1 ring-indigo-500" } else { "border-slate-700 hover:border-slate-600" })}>
+                        <input type="radio" name="server_mode" value="dual" class="sr-only" checked={*server_mode == "dual"} onchange={on_mode_change} />
+                        <span class="flex flex-1">
+                            <span class="flex flex-col">
+                                <span class="block text-sm font-medium text-white">{ "Dual Server" }</span>
+                                <span class="mt-1 flex items-center text-sm text-gray-400">{ "Tickets open in a separate staff server." }</span>
+                            </span>
+                        </span>
+                        if *server_mode == "dual" {
+                            <svg class="h-5 w-5 text-indigo-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" /></svg>
+                        }
+                    </label>
+                </div>
+            </div>
+
+            if *server_mode == "single" {
+                { render_guild_input(
+                    "Guild ID",
+                    "The ID of your server where tickets will be managed.",
+                    single_guild_id.clone(),
+                    single_guild_result.clone(),
+                    is_validating_single.clone(),
+                    on_validate_single
+                ) }
+            } else {
+                <div class="flex flex-col gap-4">
+                    { render_guild_input(
+                        "Community Guild ID",
+                        "The main server where users will DM the bot.",
+                        community_guild_id.clone(),
+                        community_guild_result.clone(),
+                        is_validating_community.clone(),
+                        on_validate_community
+                    ) }
+                    { render_guild_input(
+                        "Staff Guild ID",
+                        "The separate server where staff will answer tickets.",
+                        staff_guild_id.clone(),
+                        staff_guild_result.clone(),
+                        is_validating_staff.clone(),
+                        on_validate_staff
+                    ) }
+                </div>
+            }
+
+            <div class="flex justify-between pt-4 mt-2 border-t border-slate-800/50">
+                <button
+                    class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                    onclick={on_prev}
+                >
+                    { "Back" }
+                </button>
+                <button
+                    class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onclick={on_next}
+                    disabled={!is_valid}
+                >
+                    { "Next Step" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step2_guilds.rs
+++ b/crates/rustmail_panel/src/components/wizard/step2_guilds.rs
@@ -1,4 +1,5 @@
 use crate::components::wizard::types::{ValidateGuildRequest, ValidateGuildResponse, WizardData};
+use crate::i18n::yew::use_translation;
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -13,6 +14,7 @@ pub struct Step2Props {
 
 #[function_component(Step2Guilds)]
 pub fn step2_guilds(props: &Step2Props) -> Html {
+    let (i18n, _) = use_translation();
     let server_mode = use_state(|| {
         if props.data.server_mode.is_empty() {
             "single".to_string()
@@ -213,7 +215,7 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
                         if *is_validating {
                             <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
                         } else {
-                            { "Validate" }
+                            { i18n.t("wizard.common.verify") }
                         }
                     </button>
                 </div>
@@ -240,7 +242,7 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
     html! {
         <div class="flex flex-col gap-6 animate-fade-in">
             <div class="flex flex-col gap-4">
-                <label class="text-sm font-medium text-gray-300">{ "Select Server Mode" }</label>
+                <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step2.mode_label") }</label>
 
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <label class={format!("relative flex cursor-pointer rounded-lg border bg-slate-900/50 p-4 shadow-sm focus:outline-none transition-all {}",
@@ -248,8 +250,7 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
                         <input type="radio" name="server_mode" value="single" class="sr-only" checked={*server_mode == "single"} onchange={on_mode_change.clone()} />
                         <span class="flex flex-1">
                             <span class="flex flex-col">
-                                <span class="block text-sm font-medium text-white">{ "Single Server" }</span>
-                                <span class="mt-1 flex items-center text-sm text-gray-400">{ "Community and staff use the same server." }</span>
+                                <span class="block text-sm font-medium text-white">{ i18n.t("wizard.steps.step2.mode_single") }</span>
                             </span>
                         </span>
                         if *server_mode == "single" {
@@ -262,8 +263,7 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
                         <input type="radio" name="server_mode" value="dual" class="sr-only" checked={*server_mode == "dual"} onchange={on_mode_change} />
                         <span class="flex flex-1">
                             <span class="flex flex-col">
-                                <span class="block text-sm font-medium text-white">{ "Dual Server" }</span>
-                                <span class="mt-1 flex items-center text-sm text-gray-400">{ "Tickets open in a separate staff server." }</span>
+                                <span class="block text-sm font-medium text-white">{ i18n.t("wizard.steps.step2.mode_dual") }</span>
                             </span>
                         </span>
                         if *server_mode == "dual" {
@@ -275,8 +275,8 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
 
             if *server_mode == "single" {
                 { render_guild_input(
-                    "Guild ID",
-                    "The ID of your server where tickets will be managed.",
+                    &i18n.t("wizard.steps.step2.guilds_label"),
+                    &i18n.t("wizard.steps.step2.main_server"),
                     single_guild_id.clone(),
                     single_guild_result.clone(),
                     is_validating_single.clone(),
@@ -285,16 +285,16 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
             } else {
                 <div class="flex flex-col gap-4">
                     { render_guild_input(
-                        "Community Guild ID",
-                        "The main server where users will DM the bot.",
+                        &i18n.t("wizard.steps.step2.guilds_label"),
+                        &i18n.t("wizard.steps.step2.community_server"),
                         community_guild_id.clone(),
                         community_guild_result.clone(),
                         is_validating_community.clone(),
                         on_validate_community
                     ) }
                     { render_guild_input(
-                        "Staff Guild ID",
-                        "The separate server where staff will answer tickets.",
+                        &i18n.t("wizard.steps.step2.guilds_label"),
+                        &i18n.t("wizard.steps.step2.staff_server"),
                         staff_guild_id.clone(),
                         staff_guild_result.clone(),
                         is_validating_staff.clone(),
@@ -308,14 +308,14 @@ pub fn step2_guilds(props: &Step2Props) -> Html {
                     class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
                     onclick={on_prev}
                 >
-                    { "Back" }
+                    { i18n.t("wizard.common.back") }
                 </button>
                 <button
                     class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
                     onclick={on_next}
                     disabled={!is_valid}
                 >
-                    { "Next Step" }
+                    { i18n.t("wizard.common.next") }
                 </button>
             </div>
         </div>

--- a/crates/rustmail_panel/src/components/wizard/step3_thread.rs
+++ b/crates/rustmail_panel/src/components/wizard/step3_thread.rs
@@ -1,6 +1,7 @@
 use crate::components::wizard::types::{
     ValidateChannelRequest, ValidateChannelResponse, WizardData,
 };
+use crate::i18n::yew::use_translation;
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -15,6 +16,7 @@ pub struct Step3Props {
 
 #[function_component(Step3Thread)]
 pub fn step3_thread(props: &Step3Props) -> Html {
+    let (i18n, _) = use_translation();
     let inbox_category_id = use_state(|| props.data.inbox_category_id.clone());
     let command_prefix = use_state(|| props.data.command_prefix.clone());
     let user_color = use_state(|| props.data.user_message_color.clone());
@@ -155,13 +157,12 @@ pub fn step3_thread(props: &Step3Props) -> Html {
         <div class="flex flex-col gap-6 animate-fade-in">
             // Inbox Category
             <div class="flex flex-col gap-2 bg-slate-800/30 p-4 rounded-xl border border-slate-700/50">
-                <label class="text-sm font-medium text-gray-300">{ "Inbox Category ID" }</label>
-                <p class="text-xs text-gray-500 mb-1">{ "The Discord category ID where new tickets will be created." }</p>
+                <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step3.category_label") }</label>
                 <div class="flex gap-3">
                     <input
                         type="text"
                         class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. 123456789012345678"
+                        placeholder={i18n.t("wizard.steps.step3.category_placeholder")}
                         value={(*inbox_category_id).clone()}
                         onchange={
                             let inbox_category_id = inbox_category_id.clone();
@@ -181,7 +182,7 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                         if *is_validating {
                             <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
                         } else {
-                            { "Validate" }
+                            { i18n.t("wizard.common.verify") }
                         }
                     </button>
                 </div>
@@ -207,9 +208,10 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                 // Left Column
                 <div class="flex flex-col gap-4">
                     <div class="flex flex-col gap-2">
-                        <label class="text-sm font-medium text-gray-300">{ "Command Prefix" }</label>
+                        <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step3.prefix_label") }</label>
                         <input
                             type="text"
+                            placeholder={i18n.t("wizard.steps.step3.prefix_placeholder")}
                             class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white"
                             value={(*command_prefix).clone()}
                             onchange={
@@ -236,7 +238,7 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                                 })
                             }
                         />
-                        <label for="embedded_message" class="text-sm text-gray-300">{ "Use Embeds for Messages" }</label>
+                        <label for="embedded_message" class="text-sm text-gray-300">{ i18n.t("wizard.steps.step3.embed_label") }</label>
                     </div>
 
                     <div class="flex items-center gap-3">
@@ -253,14 +255,14 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                                 })
                             }
                         />
-                        <label for="block_quote" class="text-sm text-gray-300">{ "Use Block Quotes" }</label>
+                        <label for="block_quote" class="text-sm text-gray-300">{ i18n.t("wizard.steps.step3.use_block_quotes") }</label>
                     </div>
                 </div>
 
                 // Right Column (Colors)
                 <div class="flex flex-col gap-4">
-                    <div class="flex justify-between items-center bg-slate-900/50 p-3 rounded-lg border border-slate-800">
-                        <label class="text-sm text-gray-300">{ "User Message Color" }</label>
+                    <div class="flex flex-col gap-2">
+                        <label class="text-sm text-gray-300">{ i18n.t("wizard.steps.step3.user_message_color") }</label>
                         <input type="color" class="w-8 h-8 rounded cursor-pointer bg-transparent border-0" value={format!("#{}", (*user_color).clone().replace("#", ""))}
                             onchange={let state = user_color.clone(); Callback::from(move |e: Event| {
                                 let input: web_sys::HtmlInputElement = e.target_unchecked_into();
@@ -268,8 +270,8 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                             })}
                         />
                     </div>
-                    <div class="flex justify-between items-center bg-slate-900/50 p-3 rounded-lg border border-slate-800">
-                        <label class="text-sm text-gray-300">{ "Staff Message Color" }</label>
+                    <div class="flex flex-col gap-2">
+                        <label class="text-sm text-gray-300">{ i18n.t("wizard.steps.step3.staff_message_color") }</label>
                         <input type="color" class="w-8 h-8 rounded cursor-pointer bg-transparent border-0" value={format!("#{}", (*staff_color).clone().replace("#", ""))}
                             onchange={let state = staff_color.clone(); Callback::from(move |e: Event| {
                                 let input: web_sys::HtmlInputElement = e.target_unchecked_into();
@@ -277,8 +279,8 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                             })}
                         />
                     </div>
-                    <div class="flex justify-between items-center bg-slate-900/50 p-3 rounded-lg border border-slate-800">
-                        <label class="text-sm text-gray-300">{ "System Message Color" }</label>
+                    <div class="flex flex-col gap-2">
+                        <label class="text-sm text-gray-300">{ i18n.t("wizard.steps.step3.system_message_color") }</label>
                         <input type="color" class="w-8 h-8 rounded cursor-pointer bg-transparent border-0" value={format!("#{}", (*system_color).clone().replace("#", ""))}
                             onchange={let state = system_color.clone(); Callback::from(move |e: Event| {
                                 let input: web_sys::HtmlInputElement = e.target_unchecked_into();
@@ -294,14 +296,14 @@ pub fn step3_thread(props: &Step3Props) -> Html {
                     class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
                     onclick={on_prev}
                 >
-                    { "Back" }
+                    { i18n.t("wizard.common.back") }
                 </button>
                 <button
                     class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
                     onclick={on_next}
                     disabled={!is_valid}
                 >
-                    { "Next Step" }
+                    { i18n.t("wizard.common.next") }
                 </button>
             </div>
         </div>

--- a/crates/rustmail_panel/src/components/wizard/step3_thread.rs
+++ b/crates/rustmail_panel/src/components/wizard/step3_thread.rs
@@ -1,0 +1,309 @@
+use crate::components::wizard::types::{
+    ValidateChannelRequest, ValidateChannelResponse, WizardData,
+};
+use gloo_net::http::Request;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct Step3Props {
+    pub data: WizardData,
+    pub on_update: Callback<WizardData>,
+    pub on_next: Callback<()>,
+    pub on_prev: Callback<()>,
+}
+
+#[function_component(Step3Thread)]
+pub fn step3_thread(props: &Step3Props) -> Html {
+    let inbox_category_id = use_state(|| props.data.inbox_category_id.clone());
+    let command_prefix = use_state(|| props.data.command_prefix.clone());
+    let user_color = use_state(|| props.data.user_message_color.clone());
+    let staff_color = use_state(|| props.data.staff_message_color.clone());
+    let system_color = use_state(|| props.data.system_message_color.clone());
+
+    let embedded_message = use_state(|| props.data.embedded_message);
+    let block_quote = use_state(|| props.data.block_quote);
+    let create_ticket_by_create_channel = use_state(|| props.data.create_ticket_by_create_channel);
+    let close_on_leave = use_state(|| props.data.close_on_leave);
+
+    let is_validating = use_state(|| false);
+    let validation_result = use_state(|| None::<ValidateChannelResponse>);
+
+    // Use staff_guild_id if dual mode, else single_guild_id
+    let target_guild_id = if props.data.server_mode == "dual" {
+        props.data.staff_guild_id.clone()
+    } else {
+        props.data.single_guild_id.clone()
+    };
+
+    let on_validate_category = {
+        let category_id = inbox_category_id.clone();
+        let token = props.data.token.clone();
+        let guild_id = target_guild_id.clone();
+        let is_validating = is_validating.clone();
+        let validation_result = validation_result.clone();
+
+        Callback::from(move |_| {
+            let cat_id = (*category_id).clone();
+            if cat_id.trim().is_empty() {
+                return;
+            }
+
+            is_validating.set(true);
+            let token = token.clone();
+            let guild_id = guild_id.clone();
+            let validation_result = validation_result.clone();
+            let is_validating = is_validating.clone();
+
+            spawn_local(async move {
+                let req_body = ValidateChannelRequest {
+                    token,
+                    guild_id,
+                    channel_id: cat_id,
+                };
+
+                let res = Request::post("/api/setup/validate-channel")
+                    .json(&req_body)
+                    .unwrap()
+                    .send()
+                    .await;
+
+                match res {
+                    Ok(resp) => {
+                        if let Ok(data) = resp.json::<ValidateChannelResponse>().await {
+                            if data.valid {
+                                if let Some(chan) = &data.channel {
+                                    if chan.kind != 4 {
+                                        validation_result.set(Some(ValidateChannelResponse {
+                                            valid: false,
+                                            channel: Some(chan.clone()),
+                                            error: Some(
+                                                "The specified ID is not a category".to_string(),
+                                            ),
+                                        }));
+                                    } else {
+                                        validation_result.set(Some(data));
+                                    }
+                                }
+                            } else {
+                                validation_result.set(Some(data));
+                            }
+                        } else {
+                            validation_result.set(Some(ValidateChannelResponse {
+                                valid: false,
+                                channel: None,
+                                error: Some("Invalid response".to_string()),
+                            }));
+                        }
+                    }
+                    Err(_) => {
+                        validation_result.set(Some(ValidateChannelResponse {
+                            valid: false,
+                            channel: None,
+                            error: Some("Network error".to_string()),
+                        }));
+                    }
+                }
+
+                is_validating.set(false);
+            });
+        })
+    };
+
+    let is_valid = validation_result.as_ref().map(|r| r.valid).unwrap_or(false);
+
+    let on_next = {
+        let props_on_next = props.on_next.clone();
+        let props_on_update = props.on_update.clone();
+        let data = props.data.clone();
+
+        let inbox_category_id = inbox_category_id.clone();
+        let command_prefix = command_prefix.clone();
+        let user_color = user_color.clone();
+        let staff_color = staff_color.clone();
+        let system_color = system_color.clone();
+        let embedded_message = embedded_message.clone();
+        let block_quote = block_quote.clone();
+        let create_ticket_by_create_channel = create_ticket_by_create_channel.clone();
+        let close_on_leave = close_on_leave.clone();
+
+        Callback::from(move |_| {
+            let mut new_data = data.clone();
+            new_data.inbox_category_id = (*inbox_category_id).clone();
+            new_data.command_prefix = (*command_prefix).clone();
+            new_data.user_message_color = (*user_color).clone().replace("#", "");
+            new_data.staff_message_color = (*staff_color).clone().replace("#", "");
+            new_data.system_message_color = (*system_color).clone().replace("#", "");
+            new_data.embedded_message = *embedded_message;
+            new_data.block_quote = *block_quote;
+            new_data.create_ticket_by_create_channel = *create_ticket_by_create_channel;
+            new_data.close_on_leave = *close_on_leave;
+
+            props_on_update.emit(new_data);
+            props_on_next.emit(());
+        })
+    };
+
+    let on_prev = {
+        let props_on_prev = props.on_prev.clone();
+        Callback::from(move |_| {
+            props_on_prev.emit(());
+        })
+    };
+
+    html! {
+        <div class="flex flex-col gap-6 animate-fade-in">
+            // Inbox Category
+            <div class="flex flex-col gap-2 bg-slate-800/30 p-4 rounded-xl border border-slate-700/50">
+                <label class="text-sm font-medium text-gray-300">{ "Inbox Category ID" }</label>
+                <p class="text-xs text-gray-500 mb-1">{ "The Discord category ID where new tickets will be created." }</p>
+                <div class="flex gap-3">
+                    <input
+                        type="text"
+                        class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="e.g. 123456789012345678"
+                        value={(*inbox_category_id).clone()}
+                        onchange={
+                            let inbox_category_id = inbox_category_id.clone();
+                            let validation_result = validation_result.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                inbox_category_id.set(input.value());
+                                validation_result.set(None);
+                            })
+                        }
+                    />
+                    <button
+                        class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[100px]"
+                        onclick={on_validate_category}
+                        disabled={*is_validating || inbox_category_id.trim().is_empty()}
+                    >
+                        if *is_validating {
+                            <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+                        } else {
+                            { "Validate" }
+                        }
+                    </button>
+                </div>
+                if let Some(res) = (*validation_result).as_ref() {
+                    if res.valid {
+                        if let Some(chan) = &res.channel {
+                            <div class="mt-3 flex items-center gap-3 text-sm text-green-400">
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                { format!("Found category: {}", chan.name) }
+                            </div>
+                        }
+                    } else if let Some(error) = &res.error {
+                        <div class="mt-3 flex items-center gap-3 text-sm text-red-400">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                            { error }
+                        </div>
+                    }
+                }
+            </div>
+
+            // Other Settings (no validation required)
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                // Left Column
+                <div class="flex flex-col gap-4">
+                    <div class="flex flex-col gap-2">
+                        <label class="text-sm font-medium text-gray-300">{ "Command Prefix" }</label>
+                        <input
+                            type="text"
+                            class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white"
+                            value={(*command_prefix).clone()}
+                            onchange={
+                                let state = command_prefix.clone();
+                                Callback::from(move |e: Event| {
+                                    let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                    state.set(input.value());
+                                })
+                            }
+                        />
+                    </div>
+
+                    <div class="flex items-center gap-3 mt-2">
+                        <input
+                            type="checkbox"
+                            id="embedded_message"
+                            class="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                            checked={*embedded_message}
+                            onchange={
+                                let state = embedded_message.clone();
+                                Callback::from(move |e: Event| {
+                                    let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                    state.set(input.checked());
+                                })
+                            }
+                        />
+                        <label for="embedded_message" class="text-sm text-gray-300">{ "Use Embeds for Messages" }</label>
+                    </div>
+
+                    <div class="flex items-center gap-3">
+                        <input
+                            type="checkbox"
+                            id="block_quote"
+                            class="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                            checked={*block_quote}
+                            onchange={
+                                let state = block_quote.clone();
+                                Callback::from(move |e: Event| {
+                                    let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                    state.set(input.checked());
+                                })
+                            }
+                        />
+                        <label for="block_quote" class="text-sm text-gray-300">{ "Use Block Quotes" }</label>
+                    </div>
+                </div>
+
+                // Right Column (Colors)
+                <div class="flex flex-col gap-4">
+                    <div class="flex justify-between items-center bg-slate-900/50 p-3 rounded-lg border border-slate-800">
+                        <label class="text-sm text-gray-300">{ "User Message Color" }</label>
+                        <input type="color" class="w-8 h-8 rounded cursor-pointer bg-transparent border-0" value={format!("#{}", (*user_color).clone().replace("#", ""))}
+                            onchange={let state = user_color.clone(); Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })}
+                        />
+                    </div>
+                    <div class="flex justify-between items-center bg-slate-900/50 p-3 rounded-lg border border-slate-800">
+                        <label class="text-sm text-gray-300">{ "Staff Message Color" }</label>
+                        <input type="color" class="w-8 h-8 rounded cursor-pointer bg-transparent border-0" value={format!("#{}", (*staff_color).clone().replace("#", ""))}
+                            onchange={let state = staff_color.clone(); Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })}
+                        />
+                    </div>
+                    <div class="flex justify-between items-center bg-slate-900/50 p-3 rounded-lg border border-slate-800">
+                        <label class="text-sm text-gray-300">{ "System Message Color" }</label>
+                        <input type="color" class="w-8 h-8 rounded cursor-pointer bg-transparent border-0" value={format!("#{}", (*system_color).clone().replace("#", ""))}
+                            onchange={let state = system_color.clone(); Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })}
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex justify-between pt-4 mt-2 border-t border-slate-800/50">
+                <button
+                    class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                    onclick={on_prev}
+                >
+                    { "Back" }
+                </button>
+                <button
+                    class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onclick={on_next}
+                    disabled={!is_valid}
+                >
+                    { "Next Step" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step4_panel.rs
+++ b/crates/rustmail_panel/src/components/wizard/step4_panel.rs
@@ -1,4 +1,6 @@
-use crate::components::wizard::types::WizardData;
+use crate::components::wizard::types::{ValidateOAuth2Request, ValidateOAuth2Response, WizardData};
+use gloo_net::http::Request;
+use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
@@ -15,12 +17,97 @@ pub fn step4_panel(props: &Step4Props) -> Html {
     let api_port = use_state(|| props.data.api_port.to_string());
     let client_id = use_state(|| props.data.client_id.clone());
     let client_secret = use_state(|| props.data.client_secret.clone());
+    let redirect_url = use_state(|| props.data.redirect_url.clone());
+
+    let is_validating = use_state(|| false);
+    let validation_result = use_state(|| None::<ValidateOAuth2Response>);
+
+    // Auto-update redirect_url when panel_url or api_port changes, if the user hasn't heavily modified it manually
+    {
+        let panel_url = panel_url.clone();
+        let api_port = api_port.clone();
+        let redirect_url = redirect_url.clone();
+
+        use_effect_with((*panel_url).clone(), move |url| {
+            if !url.is_empty() {
+                let port = (*api_port).clone();
+                let has_port = url.matches(':').count() > 1; // simple check if there's a port besides http://
+
+                let base = if !has_port
+                    && (url.contains("127.0.0.1")
+                        || url.contains("localhost")
+                        || url.matches('.').count() == 3)
+                {
+                    format!("{}:{}", url, port)
+                } else {
+                    url.to_string()
+                };
+
+                redirect_url.set(format!("{}/api/auth/callback", base));
+            }
+            || ()
+        });
+    }
+
+    let validate_oauth = {
+        let client_id = client_id.clone();
+        let client_secret = client_secret.clone();
+        let is_validating = is_validating.clone();
+        let validation_result = validation_result.clone();
+
+        Callback::from(move |_| {
+            let cid = (*client_id).clone();
+            let csec = (*client_secret).clone();
+            if cid.trim().is_empty() || csec.trim().is_empty() {
+                return;
+            }
+
+            let is_validating = is_validating.clone();
+            let validation_result = validation_result.clone();
+
+            is_validating.set(true);
+
+            spawn_local(async move {
+                let req_body = ValidateOAuth2Request {
+                    client_id: cid,
+                    client_secret: csec,
+                };
+
+                let res = Request::post("/api/setup/validate-oauth2")
+                    .json(&req_body)
+                    .unwrap()
+                    .send()
+                    .await;
+
+                match res {
+                    Ok(resp) => {
+                        if let Ok(data) = resp.json::<ValidateOAuth2Response>().await {
+                            validation_result.set(Some(data));
+                        } else {
+                            validation_result.set(Some(ValidateOAuth2Response {
+                                valid: false,
+                                error: Some("Invalid response from server".to_string()),
+                            }));
+                        }
+                    }
+                    Err(_) => {
+                        validation_result.set(Some(ValidateOAuth2Response {
+                            valid: false,
+                            error: Some("Network error".to_string()),
+                        }));
+                    }
+                }
+
+                is_validating.set(false);
+            });
+        })
+    };
 
     let is_valid = !(*panel_url).trim().is_empty()
         && !(*api_port).trim().is_empty()
-        && !(*client_id).trim().is_empty()
-        && !(*client_secret).trim().is_empty()
-        && (*api_port).parse::<u16>().is_ok();
+        && !(*redirect_url).trim().is_empty()
+        && (*api_port).parse::<u16>().is_ok()
+        && validation_result.as_ref().map(|r| r.valid).unwrap_or(false);
 
     let on_next = {
         let props_on_next = props.on_next.clone();
@@ -31,6 +118,7 @@ pub fn step4_panel(props: &Step4Props) -> Html {
         let api_port = api_port.clone();
         let client_id = client_id.clone();
         let client_secret = client_secret.clone();
+        let redirect_url = redirect_url.clone();
 
         Callback::from(move |_| {
             let mut new_data = data.clone();
@@ -38,6 +126,7 @@ pub fn step4_panel(props: &Step4Props) -> Html {
             new_data.api_port = (*api_port).parse().unwrap_or(8080);
             new_data.client_id = (*client_id).clone();
             new_data.client_secret = (*client_secret).clone();
+            new_data.redirect_url = (*redirect_url).clone();
 
             props_on_update.emit(new_data);
             props_on_next.emit(());
@@ -56,9 +145,9 @@ pub fn step4_panel(props: &Step4Props) -> Html {
             <div class="bg-indigo-500/10 border border-indigo-500/20 rounded-xl p-4 flex gap-3 text-sm text-indigo-300">
                 <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                 <p>
-                    { "The web panel requires Discord OAuth2 to authenticate staff members. Make sure to add " }
-                    <strong class="text-indigo-200">{ format!("{}/api/auth/callback", if (*panel_url).is_empty() { "YOUR_URL" } else { &*panel_url }) }</strong>
-                    { " to your OAuth2 Redirect URIs in the Discord Developer Portal." }
+                    { "The web panel requires Discord OAuth2 to authenticate staff members. Make sure to add the " }
+                    <strong class="text-indigo-200">{ "Redirect URL" }</strong>
+                    { " below to your OAuth2 Redirect URIs in the Discord Developer Portal." }
                 </p>
             </div>
 
@@ -112,9 +201,11 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                         value={(*client_id).clone()}
                         onchange={
                             let state = client_id.clone();
+                            let validation_result = validation_result.clone();
                             Callback::from(move |e: Event| {
                                 let input: web_sys::HtmlInputElement = e.target_unchecked_into();
                                 state.set(input.value());
+                                validation_result.set(None);
                             })
                         }
                     />
@@ -122,19 +213,74 @@ pub fn step4_panel(props: &Step4Props) -> Html {
 
                 <div class="flex flex-col gap-2">
                     <label class="text-sm font-medium text-gray-300">{ "Discord OAuth2 Client Secret" }</label>
+                    <div class="flex gap-3">
+                        <input
+                            type="password"
+                            class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                            placeholder="Found in Developer Portal"
+                            value={(*client_secret).clone()}
+                            onchange={
+                                let state = client_secret.clone();
+                                let validation_result = validation_result.clone();
+                                Callback::from(move |e: Event| {
+                                    let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                    state.set(input.value());
+                                    validation_result.set(None);
+                                })
+                            }
+                        />
+                        <button
+                            class="px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[100px]"
+                            onclick={validate_oauth}
+                            disabled={*is_validating || client_id.trim().is_empty() || client_secret.trim().is_empty()}
+                        >
+                            if *is_validating {
+                                <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                            } else {
+                                { "Verify" }
+                            }
+                        </button>
+                    </div>
+                </div>
+
+                if let Some(result) = (*validation_result).as_ref() {
+                    <div class="md:col-span-2 mt-1">
+                        if result.valid {
+                            <div class="bg-green-500/10 border border-green-500/20 rounded-xl p-3 flex items-center gap-3">
+                                <svg class="w-5 h-5 text-green-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                <p class="text-green-400 text-sm font-medium">{ "OAuth2 credentials verified successfully!" }</p>
+                            </div>
+                        } else if let Some(error) = &result.error {
+                            <div class="bg-red-500/10 border border-red-500/20 rounded-xl p-3 flex items-start gap-3">
+                                <svg class="w-5 h-5 text-red-400 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                <div>
+                                    <p class="text-red-400 text-sm font-medium">{ "Verification Failed" }</p>
+                                    <p class="text-xs text-red-300/80 mt-0.5">{ error }</p>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+
+                <div class="flex flex-col gap-2 md:col-span-2">
+                    <label class="text-sm font-medium text-gray-300">{ "OAuth2 Redirect URL" }</label>
                     <input
-                        type="password"
-                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="Found in Developer Portal"
-                        value={(*client_secret).clone()}
+                        type="url"
+                        class="bg-slate-800/50 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="e.g. https://panel.rustmail.rs/api/auth/callback"
+                        value={(*redirect_url).clone()}
                         onchange={
-                            let state = client_secret.clone();
+                            let state = redirect_url.clone();
                             Callback::from(move |e: Event| {
                                 let input: web_sys::HtmlInputElement = e.target_unchecked_into();
                                 state.set(input.value());
                             })
                         }
                     />
+                    <p class="text-xs text-gray-500">{ "This is automatically calculated based on your panel URL and port, but you can override it if you use a reverse proxy." }</p>
                 </div>
             </div>
 

--- a/crates/rustmail_panel/src/components/wizard/step4_panel.rs
+++ b/crates/rustmail_panel/src/components/wizard/step4_panel.rs
@@ -1,0 +1,158 @@
+use crate::components::wizard::types::WizardData;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct Step4Props {
+    pub data: WizardData,
+    pub on_update: Callback<WizardData>,
+    pub on_next: Callback<()>,
+    pub on_prev: Callback<()>,
+}
+
+#[function_component(Step4Panel)]
+pub fn step4_panel(props: &Step4Props) -> Html {
+    let panel_url = use_state(|| props.data.panel_url.clone());
+    let api_port = use_state(|| props.data.api_port.to_string());
+    let client_id = use_state(|| props.data.client_id.clone());
+    let client_secret = use_state(|| props.data.client_secret.clone());
+
+    let is_valid = !(*panel_url).trim().is_empty()
+        && !(*api_port).trim().is_empty()
+        && !(*client_id).trim().is_empty()
+        && !(*client_secret).trim().is_empty()
+        && (*api_port).parse::<u16>().is_ok();
+
+    let on_next = {
+        let props_on_next = props.on_next.clone();
+        let props_on_update = props.on_update.clone();
+        let data = props.data.clone();
+
+        let panel_url = panel_url.clone();
+        let api_port = api_port.clone();
+        let client_id = client_id.clone();
+        let client_secret = client_secret.clone();
+
+        Callback::from(move |_| {
+            let mut new_data = data.clone();
+            new_data.panel_url = (*panel_url).clone();
+            new_data.api_port = (*api_port).parse().unwrap_or(8080);
+            new_data.client_id = (*client_id).clone();
+            new_data.client_secret = (*client_secret).clone();
+
+            props_on_update.emit(new_data);
+            props_on_next.emit(());
+        })
+    };
+
+    let on_prev = {
+        let props_on_prev = props.on_prev.clone();
+        Callback::from(move |_| {
+            props_on_prev.emit(());
+        })
+    };
+
+    html! {
+        <div class="flex flex-col gap-6 animate-fade-in">
+            <div class="bg-indigo-500/10 border border-indigo-500/20 rounded-xl p-4 flex gap-3 text-sm text-indigo-300">
+                <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                <p>
+                    { "The web panel requires Discord OAuth2 to authenticate staff members. Make sure to add " }
+                    <strong class="text-indigo-200">{ format!("{}/api/auth/callback", if (*panel_url).is_empty() { "YOUR_URL" } else { &*panel_url }) }</strong>
+                    { " to your OAuth2 Redirect URIs in the Discord Developer Portal." }
+                </p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-300">{ "Panel Base URL" }</label>
+                    <input
+                        type="url"
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="e.g. https://panel.rustmail.rs"
+                        value={(*panel_url).clone()}
+                        onchange={
+                            let state = panel_url.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                let mut val = input.value();
+                                // Remove trailing slash if present
+                                if val.ends_with('/') {
+                                    val.pop();
+                                }
+                                state.set(val);
+                            })
+                        }
+                    />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-300">{ "API Server Port" }</label>
+                    <input
+                        type="number"
+                        min="1" max="65535"
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="e.g. 8080"
+                        value={(*api_port).clone()}
+                        onchange={
+                            let state = api_port.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-300">{ "Discord OAuth2 Client ID" }</label>
+                    <input
+                        type="text"
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="Found in Developer Portal"
+                        value={(*client_id).clone()}
+                        onchange={
+                            let state = client_id.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-300">{ "Discord OAuth2 Client Secret" }</label>
+                    <input
+                        type="password"
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="Found in Developer Portal"
+                        value={(*client_secret).clone()}
+                        onchange={
+                            let state = client_secret.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    />
+                </div>
+            </div>
+
+            <div class="flex justify-between pt-4 mt-2 border-t border-slate-800/50">
+                <button
+                    class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                    onclick={on_prev}
+                >
+                    { "Back" }
+                </button>
+                <button
+                    class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onclick={on_next}
+                    disabled={!is_valid}
+                >
+                    { "Next Step" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step4_panel.rs
+++ b/crates/rustmail_panel/src/components/wizard/step4_panel.rs
@@ -1,4 +1,5 @@
 use crate::components::wizard::types::{ValidateOAuth2Request, ValidateOAuth2Response, WizardData};
+use crate::i18n::yew::use_translation;
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -13,6 +14,7 @@ pub struct Step4Props {
 
 #[function_component(Step4Panel)]
 pub fn step4_panel(props: &Step4Props) -> Html {
+    let (i18n, _) = use_translation();
     let panel_url = use_state(|| props.data.panel_url.clone());
     let api_port = use_state(|| props.data.api_port.to_string());
     let client_id = use_state(|| props.data.client_id.clone());
@@ -146,19 +148,17 @@ pub fn step4_panel(props: &Step4Props) -> Html {
             <div class="bg-indigo-500/10 border border-indigo-500/20 rounded-xl p-4 flex gap-3 text-sm text-indigo-300">
                 <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                 <p>
-                    { "The web panel requires Discord OAuth2 to authenticate staff members. Make sure to add the " }
-                    <strong class="text-indigo-200">{ "Redirect URL" }</strong>
-                    { " below to your OAuth2 Redirect URIs in the Discord Developer Portal." }
+                    { i18n.t("wizard.steps.step4.oauth_help") }
                 </p>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "External Panel URL" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step4.panel_url_label") }</label>
                     <input
                         type="url"
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. http://192.168.1.10:8080 or https://panel.domain.com"
+                        placeholder={i18n.t("wizard.steps.step4.panel_url_placeholder")}
                         value={(*panel_url).clone()}
                         onchange={
                             let state = panel_url.clone();
@@ -176,12 +176,12 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                 </div>
 
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "Internal API Port (Docker Bind)" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step4.api_port_label") }</label>
                     <input
                         type="number"
                         min="1" max="65535"
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. 3002 (Default)"
+                        placeholder={i18n.t("wizard.steps.step4.api_port_placeholder")}
                         value={(*api_port).clone()}
                         onchange={
                             let state = api_port.clone();
@@ -194,11 +194,11 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                 </div>
 
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "Discord OAuth2 Client ID" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step4.client_id_label") }</label>
                     <input
                         type="text"
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="Found in Developer Portal"
+                        placeholder={i18n.t("wizard.steps.step4.client_id_placeholder")}
                         value={(*client_id).clone()}
                         onchange={
                             let state = client_id.clone();
@@ -213,12 +213,12 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                 </div>
 
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "Discord OAuth2 Client Secret" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step4.client_secret_label") }</label>
                     <div class="flex gap-3">
                         <input
                             type="password"
                             class="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                            placeholder="Found in Developer Portal"
+                            placeholder={i18n.t("wizard.steps.step4.client_secret_placeholder")}
                             value={(*client_secret).clone()}
                             onchange={
                                 let state = client_secret.clone();
@@ -241,7 +241,7 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                                 </svg>
                             } else {
-                                { "Verify" }
+                                { i18n.t("wizard.common.verify") }
                             }
                         </button>
                     </div>
@@ -252,13 +252,13 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                         if result.valid {
                             <div class="bg-green-500/10 border border-green-500/20 rounded-xl p-3 flex items-center gap-3">
                                 <svg class="w-5 h-5 text-green-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                                <p class="text-green-400 text-sm font-medium">{ "OAuth2 credentials verified successfully!" }</p>
+                                <p class="text-green-400 text-sm font-medium">{ i18n.t("wizard.common.verified_success") }</p>
                             </div>
                         } else if let Some(error) = &result.error {
                             <div class="bg-red-500/10 border border-red-500/20 rounded-xl p-3 flex items-start gap-3">
                                 <svg class="w-5 h-5 text-red-400 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                 <div>
-                                    <p class="text-red-400 text-sm font-medium">{ "Verification Failed" }</p>
+                                    <p class="text-red-400 text-sm font-medium">{ i18n.t("wizard.common.verification_failed") }</p>
                                     <p class="text-xs text-red-300/80 mt-0.5">{ error }</p>
                                 </div>
                             </div>
@@ -267,11 +267,11 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                 }
 
                 <div class="flex flex-col gap-2 md:col-span-2">
-                    <label class="text-sm font-medium text-gray-300">{ "OAuth2 Redirect URL" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step4.redirect_url_label") }</label>
                     <input
                         type="url"
                         class="bg-slate-800/50 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. https://panel.rustmail.rs/api/auth/callback"
+                        placeholder={i18n.t("wizard.steps.step4.redirect_url_placeholder")}
                         value={(*redirect_url).clone()}
                         onchange={
                             let state = redirect_url.clone();
@@ -281,7 +281,7 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                             })
                         }
                     />
-                    <p class="text-xs text-gray-500">{ "This is automatically calculated based on your panel URL and port, but you can override it if you use a reverse proxy." }</p>
+                    <p class="text-xs text-gray-500">{ i18n.t("wizard.steps.step4.redirect_url_help") }</p>
                 </div>
             </div>
 
@@ -290,14 +290,14 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                     class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
                     onclick={on_prev}
                 >
-                    { "Back" }
+                    { i18n.t("wizard.common.back") }
                 </button>
                 <button
                     class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
                     onclick={on_next}
                     disabled={!is_valid}
                 >
-                    { "Next Step" }
+                    { i18n.t("wizard.common.next") }
                 </button>
             </div>
         </div>

--- a/crates/rustmail_panel/src/components/wizard/step4_panel.rs
+++ b/crates/rustmail_panel/src/components/wizard/step4_panel.rs
@@ -22,28 +22,29 @@ pub fn step4_panel(props: &Step4Props) -> Html {
     let is_validating = use_state(|| false);
     let validation_result = use_state(|| None::<ValidateOAuth2Response>);
 
-    // Auto-update redirect_url when panel_url or api_port changes, if the user hasn't heavily modified it manually
+    // Auto-update redirect_url when panel_url changes
     {
         let panel_url = panel_url.clone();
-        let api_port = api_port.clone();
         let redirect_url = redirect_url.clone();
 
         use_effect_with((*panel_url).clone(), move |url| {
             if !url.is_empty() {
-                let port = (*api_port).clone();
-                let has_port = url.matches(':').count() > 1; // simple check if there's a port besides http://
+                redirect_url.set(format!("{}/api/auth/callback", url));
+            }
+            || ()
+        });
+    }
 
-                let base = if !has_port
-                    && (url.contains("127.0.0.1")
-                        || url.contains("localhost")
-                        || url.matches('.').count() == 3)
-                {
-                    format!("{}:{}", url, port)
-                } else {
-                    url.to_string()
-                };
-
-                redirect_url.set(format!("{}/api/auth/callback", base));
+    // Auto-fill panel_url with window.location.origin on mount if empty
+    {
+        let panel_url = panel_url.clone();
+        use_effect_with((), move |_| {
+            if (*panel_url).is_empty() {
+                if let Some(window) = web_sys::window() {
+                    if let Ok(origin) = window.location().origin() {
+                        panel_url.set(origin);
+                    }
+                }
             }
             || ()
         });
@@ -153,11 +154,11 @@ pub fn step4_panel(props: &Step4Props) -> Html {
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "Panel Base URL" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ "External Panel URL" }</label>
                     <input
                         type="url"
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. https://panel.rustmail.rs"
+                        placeholder="e.g. http://192.168.1.10:8080 or https://panel.domain.com"
                         value={(*panel_url).clone()}
                         onchange={
                             let state = panel_url.clone();
@@ -175,12 +176,12 @@ pub fn step4_panel(props: &Step4Props) -> Html {
                 </div>
 
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "API Server Port" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ "Internal API Port (Docker Bind)" }</label>
                     <input
                         type="number"
                         min="1" max="65535"
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. 8080"
+                        placeholder="e.g. 3002 (Default)"
                         value={(*api_port).clone()}
                         onchange={
                             let state = api_port.clone();

--- a/crates/rustmail_panel/src/components/wizard/step5_language.rs
+++ b/crates/rustmail_panel/src/components/wizard/step5_language.rs
@@ -1,0 +1,152 @@
+use crate::components::wizard::types::WizardData;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct Step5Props {
+    pub data: WizardData,
+    pub on_update: Callback<WizardData>,
+    pub on_next: Callback<()>,
+    pub on_prev: Callback<()>,
+}
+
+#[function_component(Step5Language)]
+pub fn step5_language(props: &Step5Props) -> Html {
+    let locale = use_state(|| props.data.locale.clone());
+    let timezone = use_state(|| props.data.timezone.clone());
+    let status = use_state(|| props.data.status.clone());
+    let direct_message = use_state(|| props.data.direct_message.clone());
+
+    let is_valid = !(*status).trim().is_empty() && !(*direct_message).trim().is_empty();
+
+    let on_next = {
+        let props_on_next = props.on_next.clone();
+        let props_on_update = props.on_update.clone();
+        let data = props.data.clone();
+
+        let locale = locale.clone();
+        let timezone = timezone.clone();
+        let status = status.clone();
+        let direct_message = direct_message.clone();
+
+        Callback::from(move |_| {
+            let mut new_data = data.clone();
+            new_data.locale = (*locale).clone();
+            new_data.timezone = (*timezone).clone();
+            new_data.status = (*status).clone();
+            new_data.direct_message = (*direct_message).clone();
+
+            props_on_update.emit(new_data);
+            props_on_next.emit(());
+        })
+    };
+
+    let on_prev = {
+        let props_on_prev = props.on_prev.clone();
+        Callback::from(move |_| {
+            props_on_prev.emit(());
+        })
+    };
+
+    html! {
+        <div class="flex flex-col gap-6 animate-fade-in">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-300">{ "Language" }</label>
+                    <select
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2.5 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors cursor-pointer appearance-none"
+                        value={(*locale).clone()}
+                        onchange={
+                            let state = locale.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlSelectElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    >
+                        <option value="en">{ "English (en)" }</option>
+                        <option value="fr">{ "Français (fr)" }</option>
+                    </select>
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-300">{ "Timezone" }</label>
+                    <select
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2.5 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors cursor-pointer appearance-none"
+                        value={(*timezone).clone()}
+                        onchange={
+                            let state = timezone.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlSelectElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    >
+                        <option value="UTC">{ "UTC" }</option>
+                        <option value="Europe/Paris">{ "Europe/Paris" }</option>
+                        <option value="Europe/London">{ "Europe/London" }</option>
+                        <option value="Europe/Berlin">{ "Europe/Berlin" }</option>
+                        <option value="America/New_York">{ "America/New_York" }</option>
+                        <option value="America/Los_Angeles">{ "America/Los_Angeles" }</option>
+                        <option value="Asia/Tokyo">{ "Asia/Tokyo" }</option>
+                        <option value="Australia/Sydney">{ "Australia/Sydney" }</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="flex flex-col gap-4 bg-slate-800/30 p-5 rounded-xl border border-slate-700/50 mt-2">
+                <h3 class="text-white font-medium mb-1">{ "Bot Messages" }</h3>
+
+                <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-gray-400">{ "Bot Status / Activity" }</label>
+                    <input
+                        type="text"
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
+                        placeholder="e.g. Need help? DM me!"
+                        value={(*status).clone()}
+                        onchange={
+                            let state = status.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    />
+                    <p class="text-xs text-gray-500">{ "Displayed under the bot's name in the member list." }</p>
+                </div>
+
+                <div class="flex flex-col gap-2 mt-2">
+                    <label class="text-sm font-medium text-gray-400">{ "Welcome Message (DM)" }</label>
+                    <textarea
+                        class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors resize-none h-24"
+                        placeholder="e.g. Thank you for contacting support! A staff member will be with you shortly."
+                        value={(*direct_message).clone()}
+                        onchange={
+                            let state = direct_message.clone();
+                            Callback::from(move |e: Event| {
+                                let input: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+                                state.set(input.value());
+                            })
+                        }
+                    />
+                    <p class="text-xs text-gray-500">{ "This message is sent to the user when they open a new ticket." }</p>
+                </div>
+            </div>
+
+            <div class="flex justify-between pt-4 mt-2 border-t border-slate-800/50">
+                <button
+                    class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                    onclick={on_prev}
+                >
+                    { "Back" }
+                </button>
+                <button
+                    class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onclick={on_next}
+                    disabled={!is_valid}
+                >
+                    { "Next Step" }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step5_language.rs
+++ b/crates/rustmail_panel/src/components/wizard/step5_language.rs
@@ -1,4 +1,5 @@
 use crate::components::wizard::types::WizardData;
+use crate::i18n::yew::use_translation;
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
@@ -11,6 +12,7 @@ pub struct Step5Props {
 
 #[function_component(Step5Language)]
 pub fn step5_language(props: &Step5Props) -> Html {
+    let (i18n, _) = use_translation();
     let locale = use_state(|| props.data.locale.clone());
     let timezone = use_state(|| props.data.timezone.clone());
     let status = use_state(|| props.data.status.clone());
@@ -51,7 +53,7 @@ pub fn step5_language(props: &Step5Props) -> Html {
         <div class="flex flex-col gap-6 animate-fade-in">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "Language" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step5.language_label") }</label>
                     <select
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2.5 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors cursor-pointer appearance-none"
                         value={(*locale).clone()}
@@ -69,7 +71,7 @@ pub fn step5_language(props: &Step5Props) -> Html {
                 </div>
 
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-300">{ "Timezone" }</label>
+                    <label class="text-sm font-medium text-gray-300">{ i18n.t("wizard.steps.step5.timezone_label") }</label>
                     <select
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2.5 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors cursor-pointer appearance-none"
                         value={(*timezone).clone()}
@@ -94,14 +96,14 @@ pub fn step5_language(props: &Step5Props) -> Html {
             </div>
 
             <div class="flex flex-col gap-4 bg-slate-800/30 p-5 rounded-xl border border-slate-700/50 mt-2">
-                <h3 class="text-white font-medium mb-1">{ "Bot Messages" }</h3>
+                <h3 class="text-white font-medium mb-1">{ i18n.t("wizard.steps.step5.bot_messages_title") }</h3>
 
                 <div class="flex flex-col gap-2">
-                    <label class="text-sm font-medium text-gray-400">{ "Bot Status / Activity" }</label>
+                    <label class="text-sm font-medium text-gray-400">{ i18n.t("wizard.steps.step5.bot_status_label") }</label>
                     <input
                         type="text"
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-2 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
-                        placeholder="e.g. Need help? DM me!"
+                        placeholder={i18n.t("wizard.steps.step5.bot_status_placeholder")}
                         value={(*status).clone()}
                         onchange={
                             let state = status.clone();
@@ -111,14 +113,14 @@ pub fn step5_language(props: &Step5Props) -> Html {
                             })
                         }
                     />
-                    <p class="text-xs text-gray-500">{ "Displayed under the bot's name in the member list." }</p>
+                    <p class="text-xs text-gray-500">{ i18n.t("wizard.steps.step5.bot_status_help") }</p>
                 </div>
 
                 <div class="flex flex-col gap-2 mt-2">
-                    <label class="text-sm font-medium text-gray-400">{ "Welcome Message (DM)" }</label>
+                    <label class="text-sm font-medium text-gray-400">{ i18n.t("wizard.steps.step5.welcome_label") }</label>
                     <textarea
                         class="bg-slate-900 border border-slate-700 rounded-lg px-4 py-3 text-white focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors resize-none h-24"
-                        placeholder="e.g. Thank you for contacting support! A staff member will be with you shortly."
+                        placeholder={i18n.t("wizard.steps.step5.welcome_placeholder")}
                         value={(*direct_message).clone()}
                         onchange={
                             let state = direct_message.clone();
@@ -128,7 +130,7 @@ pub fn step5_language(props: &Step5Props) -> Html {
                             })
                         }
                     />
-                    <p class="text-xs text-gray-500">{ "This message is sent to the user when they open a new ticket." }</p>
+                    <p class="text-xs text-gray-500">{ i18n.t("wizard.steps.step5.welcome_help") }</p>
                 </div>
             </div>
 
@@ -137,14 +139,14 @@ pub fn step5_language(props: &Step5Props) -> Html {
                     class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
                     onclick={on_prev}
                 >
-                    { "Back" }
+                    { i18n.t("wizard.common.back") }
                 </button>
                 <button
                     class="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20 disabled:opacity-50 disabled:cursor-not-allowed"
                     onclick={on_next}
                     disabled={!is_valid}
                 >
-                    { "Next Step" }
+                    { i18n.t("wizard.common.next") }
                 </button>
             </div>
         </div>

--- a/crates/rustmail_panel/src/components/wizard/step6_review.rs
+++ b/crates/rustmail_panel/src/components/wizard/step6_review.rs
@@ -1,0 +1,231 @@
+use crate::components::wizard::types::WizardData;
+use gloo_net::http::Request;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct Step6Props {
+    pub data: WizardData,
+    pub on_prev: Callback<()>,
+}
+
+#[function_component(Step6Review)]
+pub fn step6_review(props: &Step6Props) -> Html {
+    let is_saving = use_state(|| false);
+    let save_success = use_state(|| false);
+    let save_error = use_state(|| None::<String>);
+
+    let on_save = {
+        let data = props.data.clone();
+        let is_saving = is_saving.clone();
+        let save_success = save_success.clone();
+        let save_error = save_error.clone();
+
+        Callback::from(move |_| {
+            is_saving.set(true);
+            save_error.set(None);
+
+            let is_saving = is_saving.clone();
+            let save_success = save_success.clone();
+            let save_error = save_error.clone();
+            let data = data.clone();
+
+            spawn_local(async move {
+                // Map WizardData to SaveConfigRequest format expected by backend
+                let req_body = serde_json::json!({
+                    "token": data.token,
+                    "bot_status": data.status,
+                    "welcome_message": data.direct_message,
+                    "close_message": "Your ticket has been closed.",
+                    "typing_proxy_from_user": true,
+                    "typing_proxy_from_staff": true,
+                    "server_mode": data.server_mode,
+                    "guild_id": if data.server_mode == "single" { data.single_guild_id.parse::<u64>().ok() } else { None },
+                    "community_guild_id": if data.server_mode == "dual" { data.community_guild_id.parse::<u64>().ok() } else { None },
+                    "staff_guild_id": if data.server_mode == "dual" { data.staff_guild_id.parse::<u64>().ok() } else { None },
+                    "enable_rustmail_logs": false,
+                    "enable_discord_logs": false,
+                    "logs_channel_id": null,
+                    "enable_features": false,
+                    "features_channel_id": null,
+                    "enable_panel": true,
+                    "client_id": data.client_id.parse::<u64>().ok(),
+                    "client_secret": data.client_secret,
+                    "redirect_url": format!("{}/api/auth/callback", data.panel_url.trim_end_matches('/')),
+                    "panel_super_admin_users": [],
+                    "inbox_category_id": data.inbox_category_id.parse::<u64>().unwrap_or(0),
+                    "command_prefix": data.command_prefix,
+                    "user_message_color": data.user_message_color,
+                    "staff_message_color": data.staff_message_color,
+                    "system_message_color": data.system_message_color,
+                    "embedded_message": data.embedded_message,
+                    "block_quote": data.block_quote,
+                    "time_to_close_thread": data.time_to_close_thread,
+                    "create_ticket_by_create_channel": data.create_ticket_by_create_channel,
+                    "close_on_leave": data.close_on_leave,
+                    "auto_archive_duration": data.auto_archive_duration,
+                    "default_language": data.locale.clone(),
+                    "fallback_language": data.locale,
+                    "timezone": data.timezone,
+                });
+
+                let res = Request::post("/api/setup/save")
+                    .json(&req_body)
+                    .unwrap()
+                    .send()
+                    .await;
+
+                match res {
+                    Ok(resp) => {
+                        if resp.ok() {
+                            save_success.set(true);
+                        } else {
+                            if let Ok(err_json) = resp.json::<serde_json::Value>().await {
+                                if let Some(err_msg) =
+                                    err_json.get("error").and_then(|e| e.as_str())
+                                {
+                                    save_error.set(Some(err_msg.to_string()));
+                                } else {
+                                    save_error
+                                        .set(Some("Failed to save configuration.".to_string()));
+                                }
+                            } else {
+                                save_error.set(Some("Failed to save configuration.".to_string()));
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        save_error.set(Some("Network error while saving.".to_string()));
+                    }
+                }
+
+                is_saving.set(false);
+            });
+        })
+    };
+
+    let on_prev = {
+        let props_on_prev = props.on_prev.clone();
+        Callback::from(move |_| {
+            props_on_prev.emit(());
+        })
+    };
+
+    if *save_success {
+        return html! {
+            <div class="flex flex-col items-center justify-center py-12 animate-fade-in text-center gap-4">
+                <div class="w-20 h-20 bg-green-500/20 rounded-full flex items-center justify-center text-green-400 mb-2 ring-4 ring-green-500/10">
+                    <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                </div>
+                <h2 class="text-2xl font-bold text-white">{ "Setup Complete!" }</h2>
+                <p class="text-gray-400 max-w-md">
+                    { "Your configuration has been saved successfully." }
+                </p>
+                <div class="mt-6 p-4 bg-slate-900 border border-slate-700 rounded-lg max-w-md w-full">
+                    <p class="text-sm text-indigo-300 font-medium mb-2">{ "Next Steps:" }</p>
+                    <ol class="text-sm text-gray-400 text-left list-decimal pl-5 space-y-2">
+                        <li>{ "Restart the Rustmail process in your terminal." }</li>
+                        <li>{ "The bot will start using the new configuration." }</li>
+                        <li>{ format!("Access the panel at {} to manage your bot.", if props.data.panel_url.is_empty() { "your configured URL" } else { &props.data.panel_url }) }</li>
+                    </ol>
+                </div>
+                <button
+                    class="mt-6 px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                    onclick={Callback::from(|_| {
+                        let _ = web_sys::window().unwrap().location().reload();
+                    })}
+                >
+                    { "Reload Page" }
+                </button>
+            </div>
+        };
+    }
+
+    html! {
+        <div class="flex flex-col gap-6 animate-fade-in">
+            <div class="bg-slate-800/30 p-5 rounded-xl border border-slate-700/50">
+                <h3 class="text-lg font-medium text-white mb-4">{ "Review Configuration" }</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+                    <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                        <span class="text-gray-400 text-sm">{ "Mode" }</span>
+                        <span class="text-white text-sm font-medium">{ if props.data.server_mode == "dual" { "Dual Server" } else { "Single Server" } }</span>
+                    </div>
+
+                    if props.data.server_mode == "single" {
+                        <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                            <span class="text-gray-400 text-sm">{ "Guild ID" }</span>
+                            <span class="text-white text-sm font-mono">{ &props.data.single_guild_id }</span>
+                        </div>
+                    } else {
+                        <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                            <span class="text-gray-400 text-sm">{ "Community Guild" }</span>
+                            <span class="text-white text-sm font-mono">{ &props.data.community_guild_id }</span>
+                        </div>
+                        <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                            <span class="text-gray-400 text-sm">{ "Staff Guild" }</span>
+                            <span class="text-white text-sm font-mono">{ &props.data.staff_guild_id }</span>
+                        </div>
+                    }
+
+                    <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                        <span class="text-gray-400 text-sm">{ "Inbox Category" }</span>
+                        <span class="text-white text-sm font-mono">{ &props.data.inbox_category_id }</span>
+                    </div>
+
+                    <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                        <span class="text-gray-400 text-sm">{ "Command Prefix" }</span>
+                        <span class="text-white text-sm font-mono">{ &props.data.command_prefix }</span>
+                    </div>
+
+                    <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                        <span class="text-gray-400 text-sm">{ "Language" }</span>
+                        <span class="text-white text-sm uppercase">{ &props.data.locale }</span>
+                    </div>
+
+                    <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                        <span class="text-gray-400 text-sm">{ "Timezone" }</span>
+                        <span class="text-white text-sm">{ &props.data.timezone }</span>
+                    </div>
+
+                    <div class="flex justify-between border-b border-slate-700/50 pb-2">
+                        <span class="text-gray-400 text-sm">{ "Panel URL" }</span>
+                        <span class="text-white text-sm font-mono">{ &props.data.panel_url }</span>
+                    </div>
+                </div>
+            </div>
+
+            if let Some(error) = (*save_error).as_ref() {
+                <div class="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
+                    <svg class="w-5 h-5 text-red-400 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                    <div>
+                        <h3 class="text-red-400 font-medium">{ "Save Failed" }</h3>
+                        <p class="text-sm text-red-300/80 mt-0.5">{ error }</p>
+                    </div>
+                </div>
+            }
+
+            <div class="flex justify-between pt-4 mt-2 border-t border-slate-800/50">
+                <button
+                    class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                    onclick={on_prev}
+                    disabled={*is_saving}
+                >
+                    { "Back" }
+                </button>
+                <button
+                    class="px-6 py-2.5 bg-green-600 hover:bg-green-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-green-600/20 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[160px]"
+                    onclick={on_save}
+                    disabled={*is_saving}
+                >
+                    if *is_saving {
+                        <svg class="animate-spin h-5 w-5 text-white mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+                        { "Saving..." }
+                    } else {
+                        { "Save & Finish" }
+                    }
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/components/wizard/step6_review.rs
+++ b/crates/rustmail_panel/src/components/wizard/step6_review.rs
@@ -120,13 +120,29 @@ pub fn step6_review(props: &Step6Props) -> Html {
     let target_url = if panel_url.is_empty() {
         format!("http://localhost:{}", api_port)
     } else {
-        let has_port = panel_url.matches(':').count() > 1;
-        if !has_port
-            && (panel_url.contains("127.0.0.1")
-                || panel_url.contains("localhost")
-                || panel_url.matches('.').count() == 3)
-        {
-            format!("{}:{}", panel_url, api_port)
+        if let Some((scheme, rest)) = panel_url.split_once("://") {
+            let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+            let authority = &rest[..authority_end];
+            let suffix = &rest[authority_end..];
+            let host_port = authority.rsplit('@').next().unwrap_or(authority);
+
+            let (host, has_port) = if let Some((host, port)) = host_port.rsplit_once(':') {
+                if port.parse::<u16>().is_ok() {
+                    (host, true)
+                } else {
+                    (host_port, false)
+                }
+            } else {
+                (host_port, false)
+            };
+
+            let is_local_host = host == "localhost" || host.parse::<std::net::Ipv4Addr>().is_ok();
+
+            if is_local_host && !has_port {
+                format!("{}://{}:{}{}", scheme, authority, api_port, suffix)
+            } else {
+                panel_url.clone()
+            }
         } else {
             panel_url.clone()
         }

--- a/crates/rustmail_panel/src/components/wizard/step6_review.rs
+++ b/crates/rustmail_panel/src/components/wizard/step6_review.rs
@@ -1,4 +1,5 @@
 use crate::components::wizard::types::WizardData;
+use crate::i18n::yew::use_translation;
 use gloo_net::http::Request;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -11,6 +12,7 @@ pub struct Step6Props {
 
 #[function_component(Step6Review)]
 pub fn step6_review(props: &Step6Props) -> Html {
+    let (i18n, _) = use_translation();
     let is_saving = use_state(|| false);
     let save_success = use_state(|| false);
     let save_error = use_state(|| None::<String>);
@@ -136,16 +138,16 @@ pub fn step6_review(props: &Step6Props) -> Html {
                 <div class="w-20 h-20 bg-green-500/20 rounded-full flex items-center justify-center text-green-400 mb-2 ring-4 ring-green-500/10">
                     <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
                 </div>
-                <h2 class="text-2xl font-bold text-white">{ "Setup Complete!" }</h2>
+                <h2 class="text-2xl font-bold text-white">{ i18n.t("wizard.steps.step6.save_success") }</h2>
                 <p class="text-gray-400 max-w-md">
-                    { "Your configuration has been saved successfully." }
+                    { i18n.t("wizard.steps.step6.success_desc") }
                 </p>
                 <div class="mt-6 p-4 bg-slate-900 border border-slate-700 rounded-lg max-w-md w-full">
-                    <p class="text-sm text-indigo-300 font-medium mb-2">{ "Next Steps:" }</p>
+                    <p class="text-sm text-indigo-300 font-medium mb-2">{ i18n.t("wizard.steps.step6.apply_changes") }</p>
                     <ol class="text-sm text-gray-400 text-left list-decimal pl-5 space-y-2">
-                        <li>{ "Click the Restart Bot button below." }</li>
-                        <li>{ "The bot will start using the new configuration." }</li>
-                        <li>{ format!("Access the panel at {} to manage your bot.", target_url) }</li>
+                        <li>{ i18n.t("wizard.steps.step6.instruction_1") }</li>
+                        <li>{ i18n.t("wizard.steps.step6.instruction_2") }</li>
+                        <li>{ i18n.t("wizard.steps.step6.instruction_3").replace("{url}", &target_url) }</li>
                     </ol>
                 </div>
                 <button
@@ -162,7 +164,7 @@ pub fn step6_review(props: &Step6Props) -> Html {
                     })}
                 >
 
-                    { "Restart Bot" }
+                    { i18n.t("wizard.steps.step6.restart_bot") }
                 </button>
             </div>
         };
@@ -171,52 +173,52 @@ pub fn step6_review(props: &Step6Props) -> Html {
     html! {
         <div class="flex flex-col gap-6 animate-fade-in">
             <div class="bg-slate-800/30 p-5 rounded-xl border border-slate-700/50">
-                <h3 class="text-lg font-medium text-white mb-4">{ "Review Configuration" }</h3>
+                <h3 class="text-lg font-medium text-white mb-4">{ i18n.t("wizard.steps.step6.title") }</h3>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
                     <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                        <span class="text-gray-400 text-sm">{ "Mode" }</span>
-                        <span class="text-white text-sm font-medium">{ if props.data.server_mode == "dual" { "Dual Server" } else { "Single Server" } }</span>
+                        <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step6.mode") }</span>
+                        <span class="text-white text-sm font-medium">{ if props.data.server_mode == "dual" { i18n.t("wizard.steps.step6.dual_server") } else { i18n.t("wizard.steps.step6.single_server") } }</span>
                     </div>
 
                     if props.data.server_mode == "single" {
                         <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                            <span class="text-gray-400 text-sm">{ "Guild ID" }</span>
+                            <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step6.guild_id") }</span>
                             <span class="text-white text-sm font-mono">{ &props.data.single_guild_id }</span>
                         </div>
                     } else {
                         <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                            <span class="text-gray-400 text-sm">{ "Community Guild" }</span>
+                            <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step6.community_guild") }</span>
                             <span class="text-white text-sm font-mono">{ &props.data.community_guild_id }</span>
                         </div>
                         <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                            <span class="text-gray-400 text-sm">{ "Staff Guild" }</span>
+                            <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step6.staff_guild") }</span>
                             <span class="text-white text-sm font-mono">{ &props.data.staff_guild_id }</span>
                         </div>
                     }
 
                     <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                        <span class="text-gray-400 text-sm">{ "Inbox Category" }</span>
+                        <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step6.category_id") }</span>
                         <span class="text-white text-sm font-mono">{ &props.data.inbox_category_id }</span>
                     </div>
 
                     <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                        <span class="text-gray-400 text-sm">{ "Command Prefix" }</span>
+                        <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step3.prefix_label") }</span>
                         <span class="text-white text-sm font-mono">{ &props.data.command_prefix }</span>
                     </div>
 
                     <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                        <span class="text-gray-400 text-sm">{ "Language" }</span>
+                        <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step5.language_label") }</span>
                         <span class="text-white text-sm uppercase">{ &props.data.locale }</span>
                     </div>
 
                     <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                        <span class="text-gray-400 text-sm">{ "Timezone" }</span>
+                        <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step5.timezone_label") }</span>
                         <span class="text-white text-sm">{ &props.data.timezone }</span>
                     </div>
 
                     <div class="flex justify-between border-b border-slate-700/50 pb-2">
-                        <span class="text-gray-400 text-sm">{ "Panel URL" }</span>
+                        <span class="text-gray-400 text-sm">{ i18n.t("wizard.steps.step4.panel_url_label") }</span>
                         <span class="text-white text-sm font-mono">{ &props.data.panel_url }</span>
                     </div>
                 </div>
@@ -226,7 +228,7 @@ pub fn step6_review(props: &Step6Props) -> Html {
                 <div class="bg-red-500/10 border border-red-500/20 rounded-xl p-4 flex items-start gap-3">
                     <svg class="w-5 h-5 text-red-400 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                     <div>
-                        <h3 class="text-red-400 font-medium">{ "Save Failed" }</h3>
+                        <h3 class="text-red-400 font-medium">{ i18n.t("wizard.steps.step6.save_failed") }</h3>
                         <p class="text-sm text-red-300/80 mt-0.5">{ error }</p>
                     </div>
                 </div>
@@ -238,7 +240,7 @@ pub fn step6_review(props: &Step6Props) -> Html {
                     onclick={on_prev}
                     disabled={*is_saving}
                 >
-                    { "Back" }
+                    { i18n.t("wizard.common.back") }
                 </button>
                 <button
                     class="px-6 py-2.5 bg-green-600 hover:bg-green-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-green-600/20 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[160px]"
@@ -247,9 +249,9 @@ pub fn step6_review(props: &Step6Props) -> Html {
                 >
                     if *is_saving {
                         <svg class="animate-spin h-5 w-5 text-white mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-                        { "Saving..." }
+                        { i18n.t("wizard.steps.step6.saving") }
                     } else {
-                        { "Save & Finish" }
+                        { i18n.t("wizard.steps.step6.save_finish") }
                     }
                 </button>
             </div>

--- a/crates/rustmail_panel/src/components/wizard/step6_review.rs
+++ b/crates/rustmail_panel/src/components/wizard/step6_review.rs
@@ -115,6 +115,21 @@ pub fn step6_review(props: &Step6Props) -> Html {
     let panel_url = props.data.panel_url.clone();
     let api_port = props.data.api_port;
 
+    let target_url = if panel_url.is_empty() {
+        format!("http://localhost:{}", api_port)
+    } else {
+        let has_port = panel_url.matches(':').count() > 1;
+        if !has_port
+            && (panel_url.contains("127.0.0.1")
+                || panel_url.contains("localhost")
+                || panel_url.matches('.').count() == 3)
+        {
+            format!("{}:{}", panel_url, api_port)
+        } else {
+            panel_url.clone()
+        }
+    };
+
     if *save_success {
         return html! {
             <div class="flex flex-col items-center justify-center py-12 animate-fade-in text-center gap-4">
@@ -130,27 +145,23 @@ pub fn step6_review(props: &Step6Props) -> Html {
                     <ol class="text-sm text-gray-400 text-left list-decimal pl-5 space-y-2">
                         <li>{ "Click the Restart Bot button below." }</li>
                         <li>{ "The bot will start using the new configuration." }</li>
-                        <li>{ format!("Access the panel at {} to manage your bot.", if props.data.panel_url.is_empty() { "your configured URL" } else { &props.data.panel_url }) }</li>
+                        <li>{ format!("Access the panel at {} to manage your bot.", target_url) }</li>
                     </ol>
                 </div>
                 <button
                     class="mt-6 px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20"
                     onclick={Callback::from(move |_| {
-                        let target_url = if panel_url.is_empty() {
-                            format!("http://localhost:{}", api_port)
-                        } else {
-                            panel_url.clone()
-                        };
-
+                        let target = target_url.clone();
                         spawn_local(async move {
                             let _ = Request::post("/api/setup/restart").send().await;
 
                             // Wait a moment before redirecting to let the server restart
                             gloo_timers::future::TimeoutFuture::new(2000).await;
-                            let _ = web_sys::window().unwrap().location().set_href(&target_url);
+                            let _ = web_sys::window().unwrap().location().set_href(&target);
                         });
                     })}
                 >
+
                     { "Restart Bot" }
                 </button>
             </div>

--- a/crates/rustmail_panel/src/components/wizard/step6_review.rs
+++ b/crates/rustmail_panel/src/components/wizard/step6_review.rs
@@ -49,9 +49,10 @@ pub fn step6_review(props: &Step6Props) -> Html {
                     "enable_features": false,
                     "features_channel_id": null,
                     "enable_panel": true,
+                    "api_port": data.api_port,
                     "client_id": data.client_id.parse::<u64>().ok(),
                     "client_secret": data.client_secret,
-                    "redirect_url": format!("{}/api/auth/callback", data.panel_url.trim_end_matches('/')),
+                    "redirect_url": data.redirect_url,
                     "panel_super_admin_users": [],
                     "inbox_category_id": data.inbox_category_id.parse::<u64>().unwrap_or(0),
                     "command_prefix": data.command_prefix,
@@ -111,6 +112,9 @@ pub fn step6_review(props: &Step6Props) -> Html {
         })
     };
 
+    let panel_url = props.data.panel_url.clone();
+    let api_port = props.data.api_port;
+
     if *save_success {
         return html! {
             <div class="flex flex-col items-center justify-center py-12 animate-fade-in text-center gap-4">
@@ -124,18 +128,30 @@ pub fn step6_review(props: &Step6Props) -> Html {
                 <div class="mt-6 p-4 bg-slate-900 border border-slate-700 rounded-lg max-w-md w-full">
                     <p class="text-sm text-indigo-300 font-medium mb-2">{ "Next Steps:" }</p>
                     <ol class="text-sm text-gray-400 text-left list-decimal pl-5 space-y-2">
-                        <li>{ "Restart the Rustmail process in your terminal." }</li>
+                        <li>{ "Click the Restart Bot button below." }</li>
                         <li>{ "The bot will start using the new configuration." }</li>
                         <li>{ format!("Access the panel at {} to manage your bot.", if props.data.panel_url.is_empty() { "your configured URL" } else { &props.data.panel_url }) }</li>
                     </ol>
                 </div>
                 <button
-                    class="mt-6 px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
-                    onclick={Callback::from(|_| {
-                        let _ = web_sys::window().unwrap().location().reload();
+                    class="mt-6 px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white font-medium rounded-lg transition-colors shadow-lg shadow-indigo-600/20"
+                    onclick={Callback::from(move |_| {
+                        let target_url = if panel_url.is_empty() {
+                            format!("http://localhost:{}", api_port)
+                        } else {
+                            panel_url.clone()
+                        };
+
+                        spawn_local(async move {
+                            let _ = Request::post("/api/setup/restart").send().await;
+
+                            // Wait a moment before redirecting to let the server restart
+                            gloo_timers::future::TimeoutFuture::new(2000).await;
+                            let _ = web_sys::window().unwrap().location().set_href(&target_url);
+                        });
                     })}
                 >
-                    { "Reload Page" }
+                    { "Restart Bot" }
                 </button>
             </div>
         };

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -88,6 +88,7 @@ pub struct ValidateGuildRequest {
     pub guild_id: String,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Clone)]
 pub struct GuildInfo {
     pub id: String,
@@ -113,7 +114,7 @@ pub struct ValidateChannelRequest {
 pub struct ChannelInfo {
     pub id: String,
     pub name: String,
-    pub kind: u8, // 4 is GUILD_CATEGORY
+    pub kind: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, PartialEq)]
 pub struct WizardData {
     pub token: String,
-    // Add other fields later for next steps
+    pub server_mode: String,
+    pub single_guild_id: String,
+    pub community_guild_id: String,
+    pub staff_guild_id: String,
 }
 
 #[derive(Serialize)]
@@ -22,5 +25,25 @@ pub struct BotInfo {
 pub struct ValidateTokenResponse {
     pub valid: bool,
     pub bot: Option<BotInfo>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidateGuildRequest {
+    pub token: String,
+    pub guild_id: String,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct GuildInfo {
+    pub id: String,
+    pub name: String,
+    pub icon: Option<String>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ValidateGuildResponse {
+    pub valid: bool,
+    pub guild: Option<GuildInfo>,
     pub error: Option<String>,
 }

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -22,6 +22,7 @@ pub struct WizardData {
     pub api_port: u16,
     pub client_id: String,
     pub client_secret: String,
+    pub redirect_url: String,
     pub locale: String,
     pub timezone: String,
     pub status: String,
@@ -51,6 +52,7 @@ impl Default for WizardData {
             api_port: 8080,
             client_id: String::new(),
             client_secret: String::new(),
+            redirect_url: String::new(),
             locale: "en".to_string(),
             timezone: "Europe/Paris".to_string(),
             status: "Need help? DM me!".to_string(),
@@ -107,16 +109,28 @@ pub struct ValidateChannelRequest {
     pub channel_id: String,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ChannelInfo {
     pub id: String,
     pub name: String,
     pub kind: u8, // 4 is GUILD_CATEGORY
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ValidateChannelResponse {
     pub valid: bool,
     pub channel: Option<ChannelInfo>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ValidateOAuth2Request {
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ValidateOAuth2Response {
+    pub valid: bool,
     pub error: Option<String>,
 }

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -49,7 +49,7 @@ impl Default for WizardData {
             close_on_leave: true,
             auto_archive_duration: 1440,
             panel_url: String::new(),
-            api_port: 8080,
+            api_port: 3002,
             client_id: String::new(),
             client_secret: String::new(),
             redirect_url: String::new(),

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -1,12 +1,46 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct WizardData {
     pub token: String,
     pub server_mode: String,
     pub single_guild_id: String,
     pub community_guild_id: String,
     pub staff_guild_id: String,
+    pub inbox_category_id: String,
+    pub command_prefix: String,
+    pub user_message_color: String,
+    pub staff_message_color: String,
+    pub system_message_color: String,
+    pub embedded_message: bool,
+    pub block_quote: bool,
+    pub time_to_close_thread: u64,
+    pub create_ticket_by_create_channel: bool,
+    pub close_on_leave: bool,
+    pub auto_archive_duration: u16,
+}
+
+impl Default for WizardData {
+    fn default() -> Self {
+        Self {
+            token: String::new(),
+            server_mode: "single".to_string(),
+            single_guild_id: String::new(),
+            community_guild_id: String::new(),
+            staff_guild_id: String::new(),
+            inbox_category_id: String::new(),
+            command_prefix: "!".to_string(),
+            user_message_color: "5865F2".to_string(),
+            staff_message_color: "ED4245".to_string(),
+            system_message_color: "FEE75C".to_string(),
+            embedded_message: true,
+            block_quote: true,
+            time_to_close_thread: 0,
+            create_ticket_by_create_channel: false,
+            close_on_leave: true,
+            auto_archive_duration: 1440,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -45,5 +79,26 @@ pub struct GuildInfo {
 pub struct ValidateGuildResponse {
     pub valid: bool,
     pub guild: Option<GuildInfo>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ValidateChannelRequest {
+    pub token: String,
+    pub guild_id: String,
+    pub channel_id: String,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ChannelInfo {
+    pub id: String,
+    pub name: String,
+    pub kind: u8, // 4 is GUILD_CATEGORY
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ValidateChannelResponse {
+    pub valid: bool,
+    pub channel: Option<ChannelInfo>,
     pub error: Option<String>,
 }

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Default, PartialEq)]
+pub struct WizardData {
+    pub token: String,
+    // Add other fields later for next steps
+}
+
+#[derive(Serialize)]
+pub struct ValidateTokenRequest {
+    pub token: String,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct BotInfo {
+    pub id: String,
+    pub username: String,
+    pub avatar: Option<String>,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct ValidateTokenResponse {
+    pub valid: bool,
+    pub bot: Option<BotInfo>,
+    pub error: Option<String>,
+}

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -22,6 +22,10 @@ pub struct WizardData {
     pub api_port: u16,
     pub client_id: String,
     pub client_secret: String,
+    pub locale: String,
+    pub timezone: String,
+    pub status: String,
+    pub direct_message: String,
 }
 
 impl Default for WizardData {
@@ -47,6 +51,12 @@ impl Default for WizardData {
             api_port: 8080,
             client_id: String::new(),
             client_secret: String::new(),
+            locale: "en".to_string(),
+            timezone: "Europe/Paris".to_string(),
+            status: "Need help? DM me!".to_string(),
+            direct_message:
+                "Thank you for contacting support! A staff member will be with you shortly."
+                    .to_string(),
         }
     }
 }

--- a/crates/rustmail_panel/src/components/wizard/types.rs
+++ b/crates/rustmail_panel/src/components/wizard/types.rs
@@ -18,6 +18,10 @@ pub struct WizardData {
     pub create_ticket_by_create_channel: bool,
     pub close_on_leave: bool,
     pub auto_archive_duration: u16,
+    pub panel_url: String,
+    pub api_port: u16,
+    pub client_id: String,
+    pub client_secret: String,
 }
 
 impl Default for WizardData {
@@ -39,6 +43,10 @@ impl Default for WizardData {
             create_ticket_by_create_channel: false,
             close_on_leave: true,
             auto_archive_duration: 1440,
+            panel_url: String::new(),
+            api_port: 8080,
+            client_id: String::new(),
+            client_secret: String::new(),
         }
     }
 }

--- a/crates/rustmail_panel/src/i18n/en/en.json
+++ b/crates/rustmail_panel/src/i18n/en/en.json
@@ -381,5 +381,118 @@
       "show_all": "Show all",
       "show_less": "Show less"
     }
+  },
+  "wizard": {
+    "title": "Rustmail Setup Wizard",
+    "progress": "Setup Progress",
+    "loading": "Loading setup...",
+    "common": {
+      "back": "Back",
+      "next": "Next Step",
+      "verify": "Verify",
+      "verified_success": "Verified successfully!",
+      "verification_failed": "Verification Failed"
+    },
+    "steps": {
+      "step1": {
+        "title": "Step 1: Discord Bot Token",
+        "description": "Let's start by linking your Discord bot. You can find your token in the Discord Developer Portal.",
+        "token_label": "Discord Bot Token",
+        "token_placeholder": "e.g. MTIz... (your token)",
+        "token_help": "Keep this secret! This gives full access to your bot.",
+        "verify_token": "Verify Token",
+        "logged_in_as": "Bot verified successfully! Logged in as "
+      },
+      "step2": {
+        "title": "Step 2: Servers Mode",
+        "description": "Choose how your bot should operate across your Discord servers.",
+        "mode_label": "Server Setup Mode",
+        "mode_single": "Single Server (Community & Staff together)",
+        "mode_dual": "Dual Servers (Separate Community and Staff servers)",
+        "guilds_label": "Guilds / Servers",
+        "main_server": "Main Server (Community & Staff)",
+        "community_server": "Community Server",
+        "staff_server": "Staff Server",
+        "loading_servers": "Loading servers..."
+      },
+      "step3": {
+        "title": "Step 3: Thread Configuration",
+        "description": "Configure your bot settings.",
+        "category_label": "Category ID for Modmail Threads",
+        "category_placeholder": "Required to create tickets",
+        "prefix_label": "Bot Command Prefix",
+        "prefix_placeholder": "e.g. ! or ?",
+        "embed_label": "Use Embedded Messages",
+        "embed_yes": "Yes",
+        "embed_no": "No",
+        "embed_help": "If Yes, bot messages will use rich Discord embeds.",
+        "autoclose_label": "Auto-close on User Leave",
+        "autoclose_help": "Automatically close threads when the user leaves the server.",
+        "close_timer_label": "Close Thread Timer (Minutes)",
+        "close_timer_placeholder": "0 to disable auto-closing",
+        "use_block_quotes": "Use Block Quotes",
+        "user_message_color": "User Message Color",
+        "staff_message_color": "Staff Message Color",
+        "system_message_color": "System Message Color"
+      },
+      "step4": {
+        "title": "Step 4: Web Panel",
+        "description": "Configure your panel settings.",
+        "oauth_help": "The web panel requires Discord OAuth2 to authenticate staff members. Make sure to add the Redirect URL below to your OAuth2 Redirect URIs in the Discord Developer Portal.",
+        "panel_url_label": "External Panel URL",
+        "panel_url_placeholder": "e.g. http://192.168.1.10:8080 or https://panel.domain.com",
+        "api_port_label": "Internal API Port (Docker Bind)",
+        "api_port_placeholder": "e.g. 3002 (Default)",
+        "client_id_label": "Discord OAuth2 Client ID",
+        "client_id_placeholder": "Found in Developer Portal",
+        "client_secret_label": "Discord OAuth2 Client Secret",
+        "client_secret_placeholder": "Found in Developer Portal",
+        "redirect_url_label": "OAuth2 Redirect URL",
+        "redirect_url_placeholder": "e.g. https://panel.rustmail.rs/api/auth/callback",
+        "redirect_url_help": "This is automatically calculated based on your panel URL, but you can override it if you use a reverse proxy."
+      },
+      "step5": {
+        "title": "Step 5: Language",
+        "description": "Configure your language and messages.",
+        "language_label": "Language",
+        "timezone_label": "Timezone",
+        "timezone_placeholder": "Select a timezone...",
+        "bot_status_label": "Bot Status / Activity",
+        "bot_status_placeholder": "e.g. Need help? DM me!",
+        "bot_status_help": "Displayed under the bot's name in the member list.",
+        "welcome_label": "Welcome Message (DM)",
+        "welcome_placeholder": "e.g. Thank you for contacting support! A staff member will be with you shortly.",
+        "welcome_help": "This message is sent to the user when they open a new ticket.",
+        "bot_messages_title": "Bot Messages"
+      },
+      "step6": {
+        "title": "Review & Save",
+        "description": "Almost done! Please review your settings.",
+        "bot_config": "Bot Configuration",
+        "token": "Token",
+        "mode": "Mode",
+        "category_id": "Category ID",
+        "panel_config": "Panel Configuration",
+        "base_url": "Base URL",
+        "port": "Port",
+        "client_id": "OAuth2 Client ID",
+        "save_finish": "Save & Finish",
+        "save_success": "Configuration Saved Successfully!",
+        "apply_changes": "To apply these changes:",
+        "instruction_1": "Click the Restart Bot button below.",
+        "instruction_2": "The bot will start using the new configuration.",
+        "instruction_3": "Access the panel at {url} to manage your bot.",
+        "success_desc": "Your configuration has been saved successfully.",
+        "go_to_panel": "Go to Panel",
+        "restart_bot": "Restart Bot",
+        "save_failed": "Failed to save configuration",
+        "dual_server": "Dual Server",
+        "single_server": "Single Server",
+        "guild_id": "Guild ID",
+        "community_guild": "Community Guild",
+        "staff_guild": "Staff Guild",
+        "saving": "Saving..."
+      }
+    }
   }
 }

--- a/crates/rustmail_panel/src/i18n/fr/fr.json
+++ b/crates/rustmail_panel/src/i18n/fr/fr.json
@@ -381,5 +381,118 @@
       "show_all": "Voir tout",
       "show_less": "Voir moins"
     }
+  },
+  "wizard": {
+    "title": "Assistant de Configuration Rustmail",
+    "progress": "Progression",
+    "loading": "Chargement...",
+    "common": {
+      "back": "Retour",
+      "next": "Étape Suivante",
+      "verify": "Vérifier",
+      "verified_success": "Vérifié avec succès !",
+      "verification_failed": "Échec de la vérification"
+    },
+    "steps": {
+      "step1": {
+        "title": "Étape 1 : Token du Bot Discord",
+        "description": "Commençons par lier votre bot Discord. Vous pouvez trouver votre token dans le Discord Developer Portal.",
+        "token_label": "Token du Bot Discord",
+        "token_placeholder": "ex: MTIz... (votre token)",
+        "token_help": "Gardez ceci secret ! Cela donne un accès complet à votre bot.",
+        "verify_token": "Vérifier le Token",
+        "logged_in_as": "Bot vérifié avec succès ! Connecté en tant que "
+      },
+      "step2": {
+        "title": "Étape 2 : Mode Serveurs",
+        "description": "Choisissez comment votre bot doit fonctionner sur vos serveurs Discord.",
+        "mode_label": "Mode de Configuration Serveur",
+        "mode_single": "Serveur Unique (Communauté & Staff ensemble)",
+        "mode_dual": "Deux Serveurs (Serveur Communauté et Serveur Staff séparés)",
+        "guilds_label": "Serveurs / Guildes",
+        "main_server": "Serveur Principal (Communauté & Staff)",
+        "community_server": "Serveur Communauté",
+        "staff_server": "Serveur Staff",
+        "loading_servers": "Chargement des serveurs..."
+      },
+      "step3": {
+        "title": "Étape 3 : Configuration des Tickets",
+        "description": "Configurez les paramètres de votre bot.",
+        "category_label": "ID de Catégorie pour les Tickets",
+        "category_placeholder": "Requis pour créer des tickets",
+        "prefix_label": "Préfixe des Commandes du Bot",
+        "prefix_placeholder": "ex: ! ou ?",
+        "embed_label": "Utiliser des Messages Intégrés (Embeds)",
+        "embed_yes": "Oui",
+        "embed_no": "Non",
+        "embed_help": "Si Oui, les messages du bot utiliseront des embeds Discord.",
+        "autoclose_label": "Fermeture Automatique au Départ",
+        "autoclose_help": "Fermer automatiquement les tickets lorsque l'utilisateur quitte le serveur.",
+        "close_timer_label": "Délai de fermeture du ticket (Minutes)",
+        "close_timer_placeholder": "0 pour désactiver la fermeture automatique",
+        "use_block_quotes": "Utiliser les citations (Block Quotes)",
+        "user_message_color": "Couleur du message utilisateur",
+        "staff_message_color": "Couleur du message staff",
+        "system_message_color": "Couleur du message système"
+      },
+      "step4": {
+        "title": "Étape 4 : Panel Web",
+        "description": "Configurez les paramètres de votre panel.",
+        "oauth_help": "Le panel web nécessite Discord OAuth2 pour authentifier les membres du staff. Assurez-vous d'ajouter l'URL de Redirection ci-dessous à vos URIs de Redirection OAuth2 dans le Discord Developer Portal.",
+        "panel_url_label": "URL Externe du Panel",
+        "panel_url_placeholder": "ex: http://192.168.1.10:8080 ou https://panel.domaine.fr",
+        "api_port_label": "Port API Interne (Docker Bind)",
+        "api_port_placeholder": "ex: 3002 (Défaut)",
+        "client_id_label": "Client ID Discord OAuth2",
+        "client_id_placeholder": "Trouvé dans le Developer Portal",
+        "client_secret_label": "Client Secret Discord OAuth2",
+        "client_secret_placeholder": "Trouvé dans le Developer Portal",
+        "redirect_url_label": "URL de Redirection OAuth2",
+        "redirect_url_placeholder": "ex: https://panel.rustmail.fr/api/auth/callback",
+        "redirect_url_help": "Ceci est calculé automatiquement d'après l'URL de votre panel, mais vous pouvez le modifier si vous utilisez un proxy inverse."
+      },
+      "step5": {
+        "title": "Étape 5 : Langue",
+        "description": "Configurez votre langue et vos messages.",
+        "language_label": "Langue",
+        "timezone_label": "Fuseau Horaire",
+        "timezone_placeholder": "Sélectionnez un fuseau horaire...",
+        "bot_status_label": "Statut / Activité du Bot",
+        "bot_status_placeholder": "ex: Besoin d'aide ? Envoyez-moi un MP !",
+        "bot_status_help": "Affiché sous le nom du bot dans la liste des membres.",
+        "welcome_label": "Message de Bienvenue (MP)",
+        "welcome_placeholder": "ex: Merci d'avoir contacté le support ! Un membre du staff va vous répondre sous peu.",
+        "welcome_help": "Ce message est envoyé à l'utilisateur lorsqu'il ouvre un nouveau ticket.",
+        "bot_messages_title": "Messages du Bot"
+      },
+      "step6": {
+        "title": "Vérification & Sauvegarde",
+        "description": "Presque terminé ! Veuillez vérifier vos paramètres.",
+        "bot_config": "Configuration du Bot",
+        "token": "Token",
+        "mode": "Mode",
+        "category_id": "ID Catégorie",
+        "panel_config": "Configuration du Panel",
+        "base_url": "URL de Base",
+        "port": "Port",
+        "client_id": "Client ID OAuth2",
+        "save_finish": "Sauvegarder & Terminer",
+        "save_success": "Configuration Sauvegardée avec Succès !",
+        "apply_changes": "Pour appliquer ces changements :",
+        "instruction_1": "Cliquez sur le bouton Redémarrer le Bot ci-dessous.",
+        "instruction_2": "Le bot va commencer à utiliser la nouvelle configuration.",
+        "instruction_3": "Accédez au panel sur {url} pour gérer votre bot.",
+        "success_desc": "Votre configuration a été sauvegardée avec succès.",
+        "go_to_panel": "Aller au Panel",
+        "restart_bot": "Redémarrer le Bot",
+        "save_failed": "Échec de la sauvegarde de la configuration",
+        "dual_server": "Serveur Double",
+        "single_server": "Serveur Unique",
+        "guild_id": "ID du Serveur",
+        "community_guild": "Serveur Communautaire",
+        "staff_guild": "Serveur Staff",
+        "saving": "Sauvegarde..."
+      }
+    }
   }
 }

--- a/crates/rustmail_panel/src/main.rs
+++ b/crates/rustmail_panel/src/main.rs
@@ -5,6 +5,7 @@ mod router;
 mod types;
 mod utils;
 
+use crate::components::setup_detector::SetupDetector;
 use crate::router::{Route, switch};
 use i18n::config::StorageType;
 use i18n::yew::I18nProvider;
@@ -27,6 +28,7 @@ fn App() -> Html {
             default_language={"en".to_string()}
         >
             <BrowserRouter>
+                <SetupDetector />
                 <Switch<Route> render={switch} />
             </BrowserRouter>
         </I18nProvider>

--- a/crates/rustmail_panel/src/pages/mod.rs
+++ b/crates/rustmail_panel/src/pages/mod.rs
@@ -2,3 +2,4 @@ pub mod administration;
 pub mod error;
 pub mod home;
 pub mod panel;
+pub mod setup;

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -1,0 +1,11 @@
+use yew::prelude::*;
+
+#[function_component(Setup)]
+pub fn setup() -> Html {
+    html! {
+        <div class="min-h-screen bg-gradient-to-b from-slate-900 to-black text-white p-8">
+            <h1 class="text-3xl font-bold mb-4">{ "Rustmail Setup Wizard" }</h1>
+            <p class="text-gray-400">{ "Welcome to the Rustmail setup wizard. This page is currently under construction." }</p>
+        </div>
+    }
+}

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -2,6 +2,7 @@ use crate::components::wizard::layout::WizardLayout;
 use crate::components::wizard::step1_token::Step1Token;
 use crate::components::wizard::step2_guilds::Step2Guilds;
 use crate::components::wizard::step3_thread::Step3Thread;
+use crate::components::wizard::step4_panel::Step4Panel;
 use crate::components::wizard::types::WizardData;
 use gloo_net::http::Request;
 use serde::Deserialize;
@@ -122,6 +123,13 @@ pub fn setup() -> Html {
                 />
             } else if *current_step == 2 {
                 <Step3Thread
+                    data={(*wizard_data).clone()}
+                    on_update={on_update_data.clone()}
+                    on_next={on_next_step.clone()}
+                    on_prev={on_prev_step.clone()}
+                />
+            } else if *current_step == 3 {
+                <Step4Panel
                     data={(*wizard_data).clone()}
                     on_update={on_update_data}
                     on_next={on_next_step}

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -4,6 +4,7 @@ use crate::components::wizard::step2_guilds::Step2Guilds;
 use crate::components::wizard::step3_thread::Step3Thread;
 use crate::components::wizard::step4_panel::Step4Panel;
 use crate::components::wizard::step5_language::Step5Language;
+use crate::components::wizard::step6_review::Step6Review;
 use crate::components::wizard::types::WizardData;
 use gloo_net::http::Request;
 use serde::Deserialize;
@@ -141,22 +142,13 @@ pub fn setup() -> Html {
                     data={(*wizard_data).clone()}
                     on_update={on_update_data}
                     on_next={on_next_step}
-                    on_prev={on_prev_step}
+                    on_prev={on_prev_step.clone()}
                 />
             } else {
-                <div class="flex flex-col gap-4">
-                    <p class="text-sm text-gray-500 text-center py-12">
-                        { "This step will be implemented soon." }
-                    </p>
-                    <div class="flex justify-start pt-4 mt-2 border-t border-slate-800/50">
-                        <button
-                            class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
-                            onclick={move |_| current_step.set(*current_step - 1)}
-                        >
-                            { "Back" }
-                        </button>
-                    </div>
-                </div>
+                <Step6Review
+                    data={(*wizard_data).clone()}
+                    on_prev={on_prev_step}
+                />
             }
         </WizardLayout>
     }

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
+#[allow(dead_code)]
 #[derive(Deserialize)]
 struct StatusResponse {
     setup_required: bool,

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -1,8 +1,45 @@
 use crate::components::wizard::layout::WizardLayout;
+use crate::components::wizard::step1_token::Step1Token;
+use crate::components::wizard::types::WizardData;
+use gloo_net::http::Request;
+use serde::Deserialize;
+use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
+
+#[derive(Deserialize)]
+struct StatusResponse {
+    setup_required: bool,
+    step: String,
+    token_prefill: Option<String>,
+}
 
 #[function_component(Setup)]
 pub fn setup() -> Html {
+    let current_step = use_state(|| 0);
+    let wizard_data = use_state(|| WizardData::default());
+    let is_loading = use_state(|| true);
+
+    {
+        let wizard_data = wizard_data.clone();
+        let is_loading = is_loading.clone();
+
+        use_effect_with((), move |_| {
+            spawn_local(async move {
+                if let Ok(resp) = Request::get("/api/setup/status").send().await {
+                    if let Ok(status) = resp.json::<StatusResponse>().await {
+                        if let Some(token) = status.token_prefill {
+                            let mut data = (*wizard_data).clone();
+                            data.token = token;
+                            wizard_data.set(data);
+                        }
+                    }
+                }
+                is_loading.set(false);
+            });
+            || ()
+        });
+    }
+
     let step_names = vec![
         "Bot Token",
         "Guilds",
@@ -12,31 +49,74 @@ pub fn setup() -> Html {
         "Review",
     ];
 
+    let on_update_data = {
+        let wizard_data = wizard_data.clone();
+        Callback::from(move |new_data: WizardData| {
+            wizard_data.set(new_data);
+        })
+    };
+
+    let on_next_step = {
+        let current_step = current_step.clone();
+        Callback::from(move |_| {
+            current_step.set(*current_step + 1);
+        })
+    };
+
+    if *is_loading {
+        return html! {
+            <div class="min-h-screen bg-slate-950 flex flex-col items-center justify-center">
+                <div class="text-gray-400 animate-pulse">{ "Loading setup..." }</div>
+            </div>
+        };
+    }
+
+    let title = match *current_step {
+        0 => "Step 1: Discord Bot Token",
+        1 => "Step 2: Servers Mode",
+        2 => "Step 3: Thread Configuration",
+        3 => "Step 4: Web Panel",
+        4 => "Step 5: Language",
+        _ => "Review & Save",
+    };
+
+    let description = match *current_step {
+        0 => {
+            "Let's start by linking your Discord bot. You can find your token in the Discord Developer Portal."
+        }
+        1 => "Choose how your bot should operate across your Discord servers.",
+        _ => "Configure your bot settings.",
+    };
+
     html! {
         <WizardLayout
-            current_step={0}
+            current_step={*current_step}
             total_steps={step_names.len()}
             step_names={step_names}
-            title={"Step 1: Discord Bot Token"}
-            description={"Let's start by linking your Discord bot. You can find your token in the Discord Developer Portal."}
+            title={title.to_string()}
+            description={description.to_string()}
         >
-            <div class="flex flex-col gap-4">
-                <div class="animate-pulse flex space-x-4">
-                    <div class="flex-1 space-y-6 py-1">
-                        <div class="h-2 bg-slate-700 rounded"></div>
-                        <div class="space-y-3">
-                            <div class="grid grid-cols-3 gap-4">
-                                <div class="h-2 bg-slate-700 rounded col-span-2"></div>
-                                <div class="h-2 bg-slate-700 rounded col-span-1"></div>
-                            </div>
-                            <div class="h-2 bg-slate-700 rounded"></div>
-                        </div>
+            if *current_step == 0 {
+                <Step1Token
+                    data={(*wizard_data).clone()}
+                    on_update={on_update_data}
+                    on_next={on_next_step}
+                />
+            } else {
+                <div class="flex flex-col gap-4">
+                    <p class="text-sm text-gray-500 text-center py-12">
+                        { "This step will be implemented soon." }
+                    </p>
+                    <div class="flex justify-start pt-4 mt-2 border-t border-slate-800/50">
+                        <button
+                            class="px-6 py-2.5 bg-slate-800 hover:bg-slate-700 text-white font-medium rounded-lg transition-colors"
+                            onclick={move |_| current_step.set(*current_step - 1)}
+                        >
+                            { "Back" }
+                        </button>
                     </div>
                 </div>
-                <p class="text-sm text-gray-500 text-center mt-8">
-                    { "The first step will be implemented in the next issue." }
-                </p>
-            </div>
+            }
         </WizardLayout>
     }
 }

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -6,6 +6,7 @@ use crate::components::wizard::step4_panel::Step4Panel;
 use crate::components::wizard::step5_language::Step5Language;
 use crate::components::wizard::step6_review::Step6Review;
 use crate::components::wizard::types::WizardData;
+use crate::i18n::yew::use_translation;
 use gloo_net::http::Request;
 use serde::Deserialize;
 use wasm_bindgen_futures::spawn_local;
@@ -20,6 +21,7 @@ struct StatusResponse {
 
 #[function_component(Setup)]
 pub fn setup() -> Html {
+    let (i18n, _) = use_translation();
     let current_step = use_state(|| 0);
     let wizard_data = use_state(|| WizardData::default());
     let is_loading = use_state(|| true);
@@ -80,26 +82,27 @@ pub fn setup() -> Html {
     if *is_loading {
         return html! {
             <div class="min-h-screen bg-slate-950 flex flex-col items-center justify-center">
-                <div class="text-gray-400 animate-pulse">{ "Loading setup..." }</div>
+                <div class="text-gray-400 animate-pulse">{ i18n.t("wizard.loading") }</div>
             </div>
         };
     }
 
     let title = match *current_step {
-        0 => "Step 1: Discord Bot Token",
-        1 => "Step 2: Servers Mode",
-        2 => "Step 3: Thread Configuration",
-        3 => "Step 4: Web Panel",
-        4 => "Step 5: Language",
-        _ => "Review & Save",
+        0 => i18n.t("wizard.steps.step1.title"),
+        1 => i18n.t("wizard.steps.step2.title"),
+        2 => i18n.t("wizard.steps.step3.title"),
+        3 => i18n.t("wizard.steps.step4.title"),
+        4 => i18n.t("wizard.steps.step5.title"),
+        _ => i18n.t("wizard.steps.step6.title"),
     };
 
     let description = match *current_step {
-        0 => {
-            "Let's start by linking your Discord bot. You can find your token in the Discord Developer Portal."
-        }
-        1 => "Choose how your bot should operate across your Discord servers.",
-        _ => "Configure your bot settings.",
+        0 => i18n.t("wizard.steps.step1.description"),
+        1 => i18n.t("wizard.steps.step2.description"),
+        2 => i18n.t("wizard.steps.step3.description"),
+        3 => i18n.t("wizard.steps.step4.description"),
+        4 => i18n.t("wizard.steps.step5.description"),
+        _ => i18n.t("wizard.steps.step6.description"),
     };
 
     html! {

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -1,5 +1,6 @@
 use crate::components::wizard::layout::WizardLayout;
 use crate::components::wizard::step1_token::Step1Token;
+use crate::components::wizard::step2_guilds::Step2Guilds;
 use crate::components::wizard::types::WizardData;
 use gloo_net::http::Request;
 use serde::Deserialize;
@@ -63,6 +64,15 @@ pub fn setup() -> Html {
         })
     };
 
+    let on_prev_step = {
+        let current_step = current_step.clone();
+        Callback::from(move |_| {
+            if *current_step > 0 {
+                current_step.set(*current_step - 1);
+            }
+        })
+    };
+
     if *is_loading {
         return html! {
             <div class="min-h-screen bg-slate-950 flex flex-col items-center justify-center">
@@ -99,8 +109,15 @@ pub fn setup() -> Html {
             if *current_step == 0 {
                 <Step1Token
                     data={(*wizard_data).clone()}
+                    on_update={on_update_data.clone()}
+                    on_next={on_next_step.clone()}
+                />
+            } else if *current_step == 1 {
+                <Step2Guilds
+                    data={(*wizard_data).clone()}
                     on_update={on_update_data}
                     on_next={on_next_step}
+                    on_prev={on_prev_step}
                 />
             } else {
                 <div class="flex flex-col gap-4">

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -3,6 +3,7 @@ use crate::components::wizard::step1_token::Step1Token;
 use crate::components::wizard::step2_guilds::Step2Guilds;
 use crate::components::wizard::step3_thread::Step3Thread;
 use crate::components::wizard::step4_panel::Step4Panel;
+use crate::components::wizard::step5_language::Step5Language;
 use crate::components::wizard::types::WizardData;
 use gloo_net::http::Request;
 use serde::Deserialize;
@@ -130,6 +131,13 @@ pub fn setup() -> Html {
                 />
             } else if *current_step == 3 {
                 <Step4Panel
+                    data={(*wizard_data).clone()}
+                    on_update={on_update_data.clone()}
+                    on_next={on_next_step.clone()}
+                    on_prev={on_prev_step.clone()}
+                />
+            } else if *current_step == 4 {
+                <Step5Language
                     data={(*wizard_data).clone()}
                     on_update={on_update_data}
                     on_next={on_next_step}

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -1,6 +1,7 @@
 use crate::components::wizard::layout::WizardLayout;
 use crate::components::wizard::step1_token::Step1Token;
 use crate::components::wizard::step2_guilds::Step2Guilds;
+use crate::components::wizard::step3_thread::Step3Thread;
 use crate::components::wizard::types::WizardData;
 use gloo_net::http::Request;
 use serde::Deserialize;
@@ -114,6 +115,13 @@ pub fn setup() -> Html {
                 />
             } else if *current_step == 1 {
                 <Step2Guilds
+                    data={(*wizard_data).clone()}
+                    on_update={on_update_data.clone()}
+                    on_next={on_next_step.clone()}
+                    on_prev={on_prev_step.clone()}
+                />
+            } else if *current_step == 2 {
+                <Step3Thread
                     data={(*wizard_data).clone()}
                     on_update={on_update_data}
                     on_next={on_next_step}

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -1,11 +1,42 @@
+use crate::components::wizard::layout::WizardLayout;
 use yew::prelude::*;
 
 #[function_component(Setup)]
 pub fn setup() -> Html {
+    let step_names = vec![
+        "Bot Token",
+        "Guilds",
+        "Thread Config",
+        "Web Panel",
+        "Language",
+        "Review",
+    ];
+
     html! {
-        <div class="min-h-screen bg-gradient-to-b from-slate-900 to-black text-white p-8">
-            <h1 class="text-3xl font-bold mb-4">{ "Rustmail Setup Wizard" }</h1>
-            <p class="text-gray-400">{ "Welcome to the Rustmail setup wizard. This page is currently under construction." }</p>
-        </div>
+        <WizardLayout
+            current_step={0}
+            total_steps={step_names.len()}
+            step_names={step_names}
+            title={"Step 1: Discord Bot Token"}
+            description={"Let's start by linking your Discord bot. You can find your token in the Discord Developer Portal."}
+        >
+            <div class="flex flex-col gap-4">
+                <div class="animate-pulse flex space-x-4">
+                    <div class="flex-1 space-y-6 py-1">
+                        <div class="h-2 bg-slate-700 rounded"></div>
+                        <div class="space-y-3">
+                            <div class="grid grid-cols-3 gap-4">
+                                <div class="h-2 bg-slate-700 rounded col-span-2"></div>
+                                <div class="h-2 bg-slate-700 rounded col-span-1"></div>
+                            </div>
+                            <div class="h-2 bg-slate-700 rounded"></div>
+                        </div>
+                    </div>
+                </div>
+                <p class="text-sm text-gray-500 text-center mt-8">
+                    { "The first step will be implemented in the next issue." }
+                </p>
+            </div>
+        </WizardLayout>
     }
 }

--- a/crates/rustmail_panel/src/pages/setup.rs
+++ b/crates/rustmail_panel/src/pages/setup.rs
@@ -49,12 +49,12 @@ pub fn setup() -> Html {
     }
 
     let step_names = vec![
-        "Bot Token",
-        "Guilds",
-        "Thread Config",
-        "Web Panel",
-        "Language",
-        "Review",
+        i18n.t("wizard.steps.step1.title").to_string(),
+        i18n.t("wizard.steps.step2.title").to_string(),
+        i18n.t("wizard.steps.step3.title").to_string(),
+        i18n.t("wizard.steps.step4.title").to_string(),
+        i18n.t("wizard.steps.step5.title").to_string(),
+        i18n.t("wizard.steps.step6.title").to_string(),
     ];
 
     let on_update_data = {

--- a/crates/rustmail_panel/src/router.rs
+++ b/crates/rustmail_panel/src/router.rs
@@ -2,6 +2,7 @@ use crate::pages::administration::Administration;
 use crate::pages::error::Error;
 use crate::pages::home::Home;
 use crate::pages::panel::Panel;
+use crate::pages::setup::Setup;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
@@ -11,6 +12,8 @@ pub enum Route {
     Home,
     #[at("/panel")]
     PanelRoot,
+    #[at("/setup")]
+    Setup,
     #[at("/panel/*")]
     Panel,
     #[at("/admin")]
@@ -26,6 +29,7 @@ pub fn switch(routes: Route) -> Html {
     match routes {
         Route::Home => html! { <Home /> },
         Route::PanelRoot | Route::Panel => html! { <Panel /> },
+        Route::Setup => html! { <Setup /> },
         Route::Administration => html! { <Administration /> },
         Route::Error => html! { <Error /> },
         Route::NotFound => html! { <h1>{ "404" }</h1> },

--- a/crates/rustmail_types/src/config/bot.rs
+++ b/crates/rustmail_types/src/config/bot.rs
@@ -33,6 +33,8 @@ pub struct BotConfig {
     pub panel_super_admin_users: Vec<u64>,
     #[serde(default)]
     pub panel_super_admin_roles: Vec<u64>,
+    #[serde(default = "default_panel_port")]
+    pub panel_port: u16,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -125,4 +127,8 @@ where
 
 fn default_timezone() -> Tz {
     chrono_tz::UTC
+}
+
+fn default_panel_port() -> u16 {
+    3002
 }


### PR DESCRIPTION
This pull request introduces several codebase cleanups and refactors, mainly focused on simplifying router construction, improving conditional logic, and removing redundant code. It also adds a new dependency, makes some minor fixes, and brings full internationalization to the frontend setup wizard.

Below are the most important changes:

### Router Construction Simplification
- Refactored all router creation functions (e.g., `create_api_router`, `create_apikeys_router`, `create_auth_router`, etc.) to return the router directly instead of assigning to a local variable and returning it, resulting in more concise and readable code.

### Conditional Logic Improvements
- Refactored many `if let` and nested `if` statements to use Rust's new "let-chains" (`if ... && let ...`) syntax, making conditions more concise and readable in several handlers and utility functions.
- Simplified some `match` statements and error handling, such as replacing a `match` with a single `.is_ok()` check.

### Code Cleanup and Redundancy Removal
- Removed redundant closing braces and unnecessary code blocks after refactoring conditionals.
- Removed local variable assignments in router functions for brevity.

### Dependency and Utility Changes
- Added the `chrono-tz` crate as a new dependency in `Cargo.toml`.
- In `config.rs`, removed local implementations of `save_config_with_backup` and `validate_config` in favor of using the versions imported from the config module, reducing code duplication.

### Minor Fixes
- Fixed a minor issue in `handle_logout` by removing an unnecessary reference in a function call.
- Changed `.or_insert_with(Vec::new)` to `.or_default()` for improved clarity in message grouping.

### Setup Wizard Internationalization (i18n)
- **Full Translation Support:** Integrated the `use_translation()` hook across all Setup Wizard steps (Step 1 to Step 6) in the `rustmail_panel` crate.
- **Language Switcher Integration:** Added the `LanguageSwitcher` component to the `WizardLayout`, allowing users to seamlessly toggle between English and French in real-time during the setup process.
- **Responsive Layout Fixes:** Adjusted the CSS positioning of the `LanguageSwitcher` to ensure it remains visible and correctly placed in the top-right corner on both desktop and mobile devices.
- **Complete i18n Dictionaries:** Updated `en.json` and `fr.json` with all the necessary keys for the setup wizard, including dynamic translations (e.g. injecting the panel URL dynamically in the final step).

### Compiler Warnings & Errors Cleanup
- **Resolved Build Errors:** Fixed two `never_loop` errors in `main.rs` that were causing the build to fail under strict lints (`clippy::never_loop`).
- **Frontend Warnings:** Fixed unused fields ("dead code") warnings during JSON deserialization in `SetupStatusResponse`, `GuildInfo`, and `StatusResponse` by explicitly allowing them.
- **Automated Clippy Fixes:** Ran `cargo clippy --fix` on the `rustmail` backend crate, automatically resolving over 200 minor linting issues across the codebase (e.g. eliminating needless memory borrows, optimizing boolean comparisons, and replacing redundant pattern matching).

---
*These changes collectively improve code readability, maintainability, and reduce redundancy across the codebase.*